### PR TITLE
本番環境デプロイワークフローとスケジュール実行を調整

### DIFF
--- a/.github/workflows/serverless-prod.yml
+++ b/.github/workflows/serverless-prod.yml
@@ -1,0 +1,47 @@
+name: serverless-prod
+
+on: pull_request
+
+jobs:
+  deploy:
+    name: deploy
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      id-token: write # OIDC トークンの発行に必要
+      contents: read
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: setup node.js
+        uses: actions/setup-node@v4
+
+      - name: setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: install sls
+        run: npm i -g serverless
+
+      - name: install plugins
+        run: npm ci
+
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ap-northeast-1
+
+      - name: get env
+        run: |
+          aws s3 cp s3://limit7412-workflow-env/analytics_notifications_slack/prod/env.yml .
+
+      - name: get secret
+        run: |
+          aws s3 cp s3://limit7412-workflow-env/analytics_notifications_slack/prod/secret.json .
+
+      - name: deploy
+        run: sls deploy --stage prod
+        env:
+          SERVERLESS_ACCESS_KEY: ${{ secrets.SERVERLESS_ACCESS_KEY }}

--- a/.github/workflows/serverless-prod.yml
+++ b/.github/workflows/serverless-prod.yml
@@ -1,6 +1,9 @@
 name: serverless-prod
 
-on: pull_request
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   deploy:

--- a/serverless.yml
+++ b/serverless.yml
@@ -14,9 +14,11 @@ plugins:
   - serverless-plugin-scripts
 
 custom:
-  defaultAccount: dummy
-  defaultDigest: dummy
   defaultStage: dev
+  # スケジュール実行は prod ステージでのみ有効にする。
+  # それ以外のステージ(dev等)ではデプロイされるが EventBridge ルールは無効化される。
+  scheduleEnabled:
+    prod: true
   scripts:
     hooks:
       # ローカルでのビルド時に bootstrap を生成する
@@ -32,4 +34,6 @@ functions:
   analyticsNotificationsSlack:
     handler: bootstrap
     events:
-      - schedule: cron(0 10 * * ? *) # UTC
+      - schedule:
+          rate: cron(0 8 * * ? *) # UTC
+          enabled: ${self:custom.scheduleEnabled.${sls:stage}, false}


### PR DESCRIPTION
本プルリクエストは、以下の変更により、本番環境へのデプロイプロセスを強化し、スケジュール実行の柔軟性を向上させます。

*   **本番環境向けServerlessデプロイワークフローを導入:**
    *   `serverless-prod.yml`をGitHub Actionsに追加します。
    *   本ワークフローは、`prod`ステージへのServerlessアプリケーションの自動デプロイを実行します。
    *   デプロイ前にS3からステージ固有の環境設定ファイルとシークレットファイルを取得する手順を含みます。
*   **スケジュール実行をステージごとに制御:**
    *   `serverless.yml`を更新し、`analyticsNotificationsSlack`関数のスケジュールイベントが`prod`ステージでのみ有効になるよう設定します。
    *   これにより、開発環境など他のステージでは、スケジュールドルールがデプロイされても無効化されます。
*   **スケジュール実行時刻を更新:**
    *   `analyticsNotificationsSlack`関数のcron式を更新し、UTCでの実行時刻を変更します。