### PR TITLE
[フェーズ2] context伝播・DI・slog導入などモダンGoイディオムへ刷新

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.0
 
 require (
 	github.com/aws/aws-lambda-go v1.54.0
+	golang.org/x/sync v0.21.0
 	google.golang.org/api v0.284.0
 )
 

--- a/handler/main.go
+++ b/handler/main.go
@@ -2,27 +2,31 @@ package main
 
 import (
 	"context"
+	"log/slog"
 
-	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/limit7412/analytics_notifications_slack/repository"
 	"github.com/limit7412/analytics_notifications_slack/usecase"
 )
 
-// Response is of type APIGatewayProxyResponse since we're leveraging the
-// AWS Lambda Proxy Request functionality (default behavior)
-//
-// https://serverless.com/framework/docs/providers/aws/events/apigateway/#lambda-proxy-integration
-type Response events.CloudWatchEvent
+// Handler is our lambda handler invoked by the `lambda.Start` function call.
+// It is triggered on a schedule (EventBridge), so it takes no input payload.
+func Handler(ctx context.Context) error {
+	slack := repository.NewSlackRepository()
 
-// Handler is our lambda handler invoked by the `lambda.Start` function call
-func Handler(ctx context.Context) (Response, error) {
-	app := usecase.NewNotifyUsecase()
-	err := app.Run()
+	analytics, err := repository.NewAnalyticsRepository(ctx)
 	if err != nil {
-		app.Error(err)
+		slog.ErrorContext(ctx, "failed to init analytics repository", slog.Any("error", err))
+		return err
 	}
 
-	return Response{}, nil
+	app := usecase.NewNotifyUsecase(analytics, slack)
+	if err := app.Run(ctx); err != nil {
+		app.Error(ctx, err)
+		return err
+	}
+
+	return nil
 }
 
 func main() {

--- a/handler/main.go
+++ b/handler/main.go
@@ -16,9 +16,15 @@ var (
 	analyticsRepo repository.AnalyticsRepository
 )
 
+// Response はハンドラーの実行結果を表す。
+// テスト等で実行結果を判定できるよう、成功時にも返却する。
+type Response struct {
+	Message string `json:"message"`
+}
+
 // Handler は `lambda.Start` から呼び出される Lambda ハンドラー。
 // スケジュール(EventBridge)起動のため、入力ペイロードは受け取らない。
-func Handler(ctx context.Context) error {
+func Handler(ctx context.Context) (Response, error) {
 	if slackRepo == nil {
 		slackRepo = repository.NewSlackRepository()
 	}
@@ -31,7 +37,7 @@ func Handler(ctx context.Context) error {
 			err = fmt.Errorf("init analytics repository: %w", err)
 			// slackRepo は生成済みなので、この経路でも失敗通知を送る。
 			usecase.NewNotifyUsecase(nil, slackRepo).Error(ctx, err)
-			return err
+			return Response{}, err
 		}
 		analyticsRepo = repo
 	}
@@ -39,10 +45,10 @@ func Handler(ctx context.Context) error {
 	app := usecase.NewNotifyUsecase(analyticsRepo, slackRepo)
 	if err := app.Run(ctx); err != nil {
 		app.Error(ctx, err)
-		return err
+		return Response{}, err
 	}
 
-	return nil
+	return Response{Message: "success"}, nil
 }
 
 func main() {

--- a/handler/main.go
+++ b/handler/main.go
@@ -9,27 +9,27 @@ import (
 	"github.com/limit7412/analytics_notifications_slack/usecase"
 )
 
-// Repositories are initialised lazily and cached across warm Lambda
-// invocations to avoid re-establishing connections/credentials every call.
+// リポジトリは遅延初期化し、Lambda のウォームスタート間でキャッシュ・再利用する
+// ことで、呼び出しごとの接続・認証情報の再確立コストを避ける。
 var (
 	slackRepo     repository.SlackRepository
 	analyticsRepo repository.AnalyticsRepository
 )
 
-// Handler is our lambda handler invoked by the `lambda.Start` function call.
-// It is triggered on a schedule (EventBridge), so it takes no input payload.
+// Handler は `lambda.Start` から呼び出される Lambda ハンドラー。
+// スケジュール(EventBridge)起動のため、入力ペイロードは受け取らない。
 func Handler(ctx context.Context) error {
 	if slackRepo == nil {
 		slackRepo = repository.NewSlackRepository()
 	}
 
 	if analyticsRepo == nil {
-		// Use a background context so the cached service is not bound to a
-		// single invocation's (cancellable) context.
+		// キャッシュするサービスを単一呼び出しの(キャンセルされうる)コンテキストに
+		// 紐付けないよう、background コンテキストで生成する。
 		repo, err := repository.NewAnalyticsRepository(context.Background())
 		if err != nil {
 			err = fmt.Errorf("init analytics repository: %w", err)
-			// slackRepo is already available, so still surface the failure.
+			// slackRepo は生成済みなので、この経路でも失敗通知を送る。
 			usecase.NewNotifyUsecase(nil, slackRepo).Error(ctx, err)
 			return err
 		}

--- a/handler/main.go
+++ b/handler/main.go
@@ -2,25 +2,41 @@ package main
 
 import (
 	"context"
-	"log/slog"
+	"fmt"
 
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/limit7412/analytics_notifications_slack/repository"
 	"github.com/limit7412/analytics_notifications_slack/usecase"
 )
 
+// Repositories are initialised lazily and cached across warm Lambda
+// invocations to avoid re-establishing connections/credentials every call.
+var (
+	slackRepo     repository.SlackRepository
+	analyticsRepo repository.AnalyticsRepository
+)
+
 // Handler is our lambda handler invoked by the `lambda.Start` function call.
 // It is triggered on a schedule (EventBridge), so it takes no input payload.
 func Handler(ctx context.Context) error {
-	slack := repository.NewSlackRepository()
-
-	analytics, err := repository.NewAnalyticsRepository(ctx)
-	if err != nil {
-		slog.ErrorContext(ctx, "failed to init analytics repository", slog.Any("error", err))
-		return err
+	if slackRepo == nil {
+		slackRepo = repository.NewSlackRepository()
 	}
 
-	app := usecase.NewNotifyUsecase(analytics, slack)
+	if analyticsRepo == nil {
+		// Use a background context so the cached service is not bound to a
+		// single invocation's (cancellable) context.
+		repo, err := repository.NewAnalyticsRepository(context.Background())
+		if err != nil {
+			err = fmt.Errorf("init analytics repository: %w", err)
+			// slackRepo is already available, so still surface the failure.
+			usecase.NewNotifyUsecase(nil, slackRepo).Error(ctx, err)
+			return err
+		}
+		analyticsRepo = repo
+	}
+
+	app := usecase.NewNotifyUsecase(analyticsRepo, slackRepo)
 	if err := app.Run(ctx); err != nil {
 		app.Error(ctx, err)
 		return err

--- a/repository/analytics.go
+++ b/repository/analytics.go
@@ -1,9 +1,12 @@
 package repository
 
 import (
+	"cmp"
 	"context"
+	"fmt"
+	"maps"
 	"os"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -12,15 +15,21 @@ import (
 )
 
 type AnalyticsRepository interface {
-	GetSessions(start string, end string) ([]*Page, error)
+	GetSessions(ctx context.Context, start string, end string) ([]*Page, error)
 }
 
 type analyticsImpl struct {
+	service *analytics.Service
 }
 
 // NewAnalyticsRepository access to analytics
-func NewAnalyticsRepository() AnalyticsRepository {
-	return &analyticsImpl{}
+func NewAnalyticsRepository(ctx context.Context) (AnalyticsRepository, error) {
+	service, err := analytics.NewService(ctx, option.WithCredentialsFile("./secret.json"))
+	if err != nil {
+		return nil, fmt.Errorf("create analytics service: %w", err)
+	}
+
+	return &analyticsImpl{service: service}, nil
 }
 
 type Page struct {
@@ -29,22 +38,7 @@ type Page struct {
 	PV    int
 }
 
-func (a *analyticsImpl) getService() (*analytics.Service, error) {
-	ctx := context.Background()
-	analyticsService, err := analytics.NewService(ctx, option.WithCredentialsFile("./secret.json"))
-	if err != nil {
-		return nil, err
-	}
-
-	return analyticsService, nil
-}
-
-func (a *analyticsImpl) GetSessions(start string, end string) ([]*Page, error) {
-	service, err := a.getService()
-	if err != nil {
-		return nil, err
-	}
-
+func (a *analyticsImpl) GetSessions(ctx context.Context, start string, end string) ([]*Page, error) {
 	runReportRequest := &analytics.RunReportRequest{
 		DateRanges: []*analytics.DateRange{
 			{StartDate: start, EndDate: end},
@@ -61,9 +55,9 @@ func (a *analyticsImpl) GetSessions(start string, end string) ([]*Page, error) {
 
 	pageMap := make(map[string]*Page)
 	for _, propertyId := range strings.Split(os.Getenv("PROPERTY_ID"), ",") {
-		data, err := service.Properties.RunReport("properties/"+propertyId, runReportRequest).Do()
+		data, err := a.service.Properties.RunReport("properties/"+propertyId, runReportRequest).Context(ctx).Do()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("run report for property %s: %w", propertyId, err)
 		}
 
 		for _, row := range data.Rows {
@@ -79,7 +73,7 @@ func (a *analyticsImpl) GetSessions(start string, end string) ([]*Page, error) {
 			title := strings.Split(pageTitle, os.Getenv("TITLE_SPLIT"))[0]
 			pv, err := strconv.Atoi(screenPageViews)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("parse screenPageViews %q: %w", screenPageViews, err)
 			}
 			if _, ok := pageMap[title]; ok {
 				pageMap[title].PV += pv
@@ -93,13 +87,9 @@ func (a *analyticsImpl) GetSessions(start string, end string) ([]*Page, error) {
 		}
 	}
 
-	result := []*Page{}
-	for _, item := range pageMap {
-		result = append(result, item)
-	}
-
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].PV > result[j].PV
+	result := slices.Collect(maps.Values(pageMap))
+	slices.SortFunc(result, func(a, b *Page) int {
+		return cmp.Compare(b.PV, a.PV)
 	})
 
 	return result, nil

--- a/repository/analytics.go
+++ b/repository/analytics.go
@@ -22,7 +22,7 @@ type analyticsImpl struct {
 	service *analytics.Service
 }
 
-// NewAnalyticsRepository access to analytics
+// NewAnalyticsRepository は Google アナリティクスへアクセスするリポジトリを生成する
 func NewAnalyticsRepository(ctx context.Context) (AnalyticsRepository, error) {
 	service, err := analytics.NewService(ctx, option.WithCredentialsFile("./secret.json"))
 	if err != nil {
@@ -73,8 +73,8 @@ func (a *analyticsImpl) GetSessions(ctx context.Context, start string, end strin
 		}
 	}
 
-	// Treat a missing/empty PROPERTY_ID as a configuration error rather than
-	// silently returning an empty (but "successful") ranking.
+	// PROPERTY_ID が未設定/空の場合、空の(だが"成功"扱いの)ランキングを黙って
+	// 返すのではなく、設定不備のエラーとして扱う。
 	if processed == 0 {
 		return nil, fmt.Errorf("no valid PROPERTY_ID configured")
 	}
@@ -82,9 +82,9 @@ func (a *analyticsImpl) GetSessions(ctx context.Context, start string, end strin
 	return sortPages(pageMap), nil
 }
 
-// aggregateRows folds report rows into pageMap, summing PV for duplicate titles.
-// Top-level paths (a single "/") are skipped. Rows missing the expected
-// dimensions or metrics are skipped defensively to avoid panics.
+// aggregateRows はレポートの行を pageMap に集約し、同一タイトルの PV を合算する。
+// トップレベルのパス(スラッシュ1つ)はスキップする。想定するディメンション/
+// メトリクスを欠く行は、panic を避けるため防御的にスキップする。
 func aggregateRows(pageMap map[string]*Page, rows []*analytics.Row, titleSplit string) error {
 	for _, row := range rows {
 		if row == nil || len(row.DimensionValues) < 3 || len(row.MetricValues) < 1 {
@@ -122,7 +122,7 @@ func aggregateRows(pageMap map[string]*Page, rows []*analytics.Row, titleSplit s
 	return nil
 }
 
-// sortPages returns the pages sorted by descending PV.
+// sortPages はページを PV の降順に並べて返す。
 func sortPages(pageMap map[string]*Page) []*Page {
 	result := slices.Collect(maps.Values(pageMap))
 	slices.SortFunc(result, func(a, b *Page) int {

--- a/repository/analytics.go
+++ b/repository/analytics.go
@@ -55,11 +55,13 @@ func (a *analyticsImpl) GetSessions(ctx context.Context, start string, end strin
 
 	titleSplit := os.Getenv("TITLE_SPLIT")
 	pageMap := make(map[string]*Page)
+	processed := 0
 	for _, propertyId := range strings.Split(os.Getenv("PROPERTY_ID"), ",") {
 		id := strings.TrimSpace(propertyId)
 		if id == "" {
 			continue
 		}
+		processed++
 
 		data, err := a.service.Properties.RunReport("properties/"+id, runReportRequest).Context(ctx).Do()
 		if err != nil {
@@ -69,6 +71,12 @@ func (a *analyticsImpl) GetSessions(ctx context.Context, start string, end strin
 		if err := aggregateRows(pageMap, data.Rows, titleSplit); err != nil {
 			return nil, err
 		}
+	}
+
+	// Treat a missing/empty PROPERTY_ID as a configuration error rather than
+	// silently returning an empty (but "successful") ranking.
+	if processed == 0 {
+		return nil, fmt.Errorf("no valid PROPERTY_ID configured")
 	}
 
 	return sortPages(pageMap), nil

--- a/repository/analytics.go
+++ b/repository/analytics.go
@@ -53,44 +53,73 @@ func (a *analyticsImpl) GetSessions(ctx context.Context, start string, end strin
 		},
 	}
 
+	titleSplit := os.Getenv("TITLE_SPLIT")
 	pageMap := make(map[string]*Page)
 	for _, propertyId := range strings.Split(os.Getenv("PROPERTY_ID"), ",") {
-		data, err := a.service.Properties.RunReport("properties/"+propertyId, runReportRequest).Context(ctx).Do()
-		if err != nil {
-			return nil, fmt.Errorf("run report for property %s: %w", propertyId, err)
+		id := strings.TrimSpace(propertyId)
+		if id == "" {
+			continue
 		}
 
-		for _, row := range data.Rows {
-			pageTitle := row.DimensionValues[0].Value
-			hostName := row.DimensionValues[1].Value
-			pagePath := row.DimensionValues[2].Value
-			screenPageViews := row.MetricValues[0].Value
+		data, err := a.service.Properties.RunReport("properties/"+id, runReportRequest).Context(ctx).Do()
+		if err != nil {
+			return nil, fmt.Errorf("run report for property %s: %w", id, err)
+		}
 
-			if strings.Count(pagePath, "/") == 1 {
-				continue
-			}
+		if err := aggregateRows(pageMap, data.Rows, titleSplit); err != nil {
+			return nil, err
+		}
+	}
 
-			title := strings.Split(pageTitle, os.Getenv("TITLE_SPLIT"))[0]
-			pv, err := strconv.Atoi(screenPageViews)
-			if err != nil {
-				return nil, fmt.Errorf("parse screenPageViews %q: %w", screenPageViews, err)
-			}
-			if _, ok := pageMap[title]; ok {
-				pageMap[title].PV += pv
-			} else {
-				pageMap[title] = &Page{
-					Title: title,
-					Path:  hostName + pagePath,
-					PV:    pv,
-				}
+	return sortPages(pageMap), nil
+}
+
+// aggregateRows folds report rows into pageMap, summing PV for duplicate titles.
+// Top-level paths (a single "/") are skipped. Rows missing the expected
+// dimensions or metrics are skipped defensively to avoid panics.
+func aggregateRows(pageMap map[string]*Page, rows []*analytics.Row, titleSplit string) error {
+	for _, row := range rows {
+		if row == nil || len(row.DimensionValues) < 3 || len(row.MetricValues) < 1 {
+			continue
+		}
+
+		pageTitle := row.DimensionValues[0].Value
+		hostName := row.DimensionValues[1].Value
+		pagePath := row.DimensionValues[2].Value
+		screenPageViews := row.MetricValues[0].Value
+
+		if strings.Count(pagePath, "/") == 1 {
+			continue
+		}
+
+		title := pageTitle
+		if titleSplit != "" {
+			title = strings.Split(pageTitle, titleSplit)[0]
+		}
+		pv, err := strconv.Atoi(screenPageViews)
+		if err != nil {
+			return fmt.Errorf("parse screenPageViews %q: %w", screenPageViews, err)
+		}
+		if _, ok := pageMap[title]; ok {
+			pageMap[title].PV += pv
+		} else {
+			pageMap[title] = &Page{
+				Title: title,
+				Path:  hostName + pagePath,
+				PV:    pv,
 			}
 		}
 	}
 
+	return nil
+}
+
+// sortPages returns the pages sorted by descending PV.
+func sortPages(pageMap map[string]*Page) []*Page {
 	result := slices.Collect(maps.Values(pageMap))
 	slices.SortFunc(result, func(a, b *Page) int {
 		return cmp.Compare(b.PV, a.PV)
 	})
 
-	return result, nil
+	return result
 }

--- a/repository/slack.go
+++ b/repository/slack.go
@@ -19,7 +19,7 @@ type slackImpl struct {
 	client *http.Client
 }
 
-// NewSlackRepository access to slack
+// NewSlackRepository は Slack へアクセスするリポジトリを生成する
 func NewSlackRepository() SlackRepository {
 	return &slackImpl{
 		client: &http.Client{Timeout: 10 * time.Second},

--- a/repository/slack.go
+++ b/repository/slack.go
@@ -1,22 +1,29 @@
 package repository
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
+	"strings"
+	"time"
 )
 
 type SlackRepository interface {
-	Post(path string, msg []*Post) error
+	Post(ctx context.Context, path string, msg []*Post) error
 }
 
 type slackImpl struct {
+	client *http.Client
 }
 
 // NewSlackRepository access to slack
 func NewSlackRepository() SlackRepository {
-	return &slackImpl{}
+	return &slackImpl{
+		client: &http.Client{Timeout: 10 * time.Second},
+	}
 }
 
 type Post struct {
@@ -32,20 +39,32 @@ type payload struct {
 	Attachments []*Post `json:"attachments"`
 }
 
-func (a *slackImpl) Post(path string, msg []*Post) error {
+func (a *slackImpl) Post(ctx context.Context, path string, msg []*Post) error {
 	params, err := json.Marshal(payload{
 		Attachments: msg,
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("marshal slack payload: %w", err)
 	}
-	payload := url.Values{"payload": {string(params)}}
-	fmt.Print(payload)
-	res, err := http.PostForm(path, payload)
+
+	body := url.Values{"payload": {string(params)}}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, path, strings.NewReader(body.Encode()))
 	if err != nil {
-		return err
+		return fmt.Errorf("create slack request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	res, err := a.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("post to slack: %w", err)
 	}
 	defer res.Body.Close()
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		resBody, _ := io.ReadAll(io.LimitReader(res.Body, 1024))
+		return fmt.Errorf("slack returned status %d: %s", res.StatusCode, strings.TrimSpace(string(resBody)))
+	}
+	_, _ = io.Copy(io.Discard, res.Body)
 
 	return nil
 }

--- a/usecase/notify.go
+++ b/usecase/notify.go
@@ -22,7 +22,7 @@ type notifyImpl struct {
 	slack     repository.SlackRepository
 }
 
-// NewNotifyUsecase notification analytics to slack
+// NewNotifyUsecase は分析結果を Slack へ通知するユースケースを生成する
 func NewNotifyUsecase(analytics repository.AnalyticsRepository, slack repository.SlackRepository) NotifyUsecase {
 	return &notifyImpl{
 		analytics: analytics,
@@ -46,8 +46,7 @@ func (n *notifyImpl) Run(ctx context.Context) error {
 		{"累計pv数ランキング", "#41a300", "2015-08-14", today},
 	}
 
-	// Fetch each date range concurrently; results are stored by index to
-	// preserve the original ordering.
+	// 各期間を並列に取得する。結果はインデックスで格納し、元の順序を保持する。
 	rankings := make([]*repository.Post, len(ranges))
 	g, ctx := errgroup.WithContext(ctx)
 	for i, r := range ranges {
@@ -91,8 +90,8 @@ func (n *notifyImpl) Error(ctx context.Context, err error) {
 		},
 	}
 
-	// Use a detached context so the failure notification is still delivered
-	// even when the incoming ctx was already cancelled (e.g. Lambda timeout).
+	// 渡された ctx が既にキャンセル済み(例: Lambda タイムアウト)でも失敗通知を
+	// 届けられるよう、キャンセルを切り離したコンテキストを使う。
 	notifyCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 	defer cancel()
 

--- a/usecase/notify.go
+++ b/usecase/notify.go
@@ -1,7 +1,9 @@
 package usecase
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 	"time"
@@ -10,73 +12,77 @@ import (
 )
 
 type NotifyUsecase interface {
-	Run() error
-	Error(err error)
+	Run(ctx context.Context) error
+	Error(ctx context.Context, err error)
 }
 
 type notifyImpl struct {
+	analytics repository.AnalyticsRepository
+	slack     repository.SlackRepository
 }
 
 // NewNotifyUsecase notification analytics to slack
-func NewNotifyUsecase() NotifyUsecase {
-	return &notifyImpl{}
+func NewNotifyUsecase(analytics repository.AnalyticsRepository, slack repository.SlackRepository) NotifyUsecase {
+	return &notifyImpl{
+		analytics: analytics,
+		slack:     slack,
+	}
 }
 
-func (n *notifyImpl) Run() error {
-	post := []*repository.Post{}
-	post = append(post, &repository.Post{
-		Fallback: os.Getenv("SUCCESS_FALLBACK"),
-		Pretext:  os.Getenv("SUCCESS_FALLBACK"),
-	})
+func (n *notifyImpl) Run(ctx context.Context) error {
+	now := time.Now()
+	today := now.Format("2006-01-02")
+	month := now.AddDate(0, 0, -(now.Day() - 1)).Format("2006-01-02")
 
-	today := time.Now().Format("2006-01-02")
-
-	adp := repository.NewAnalyticsRepository()
-	data, err := adp.GetSessions(today, today)
-	if err != nil {
-		return err
+	posts := []*repository.Post{
+		{
+			Fallback: os.Getenv("SUCCESS_FALLBACK"),
+			Pretext:  os.Getenv("SUCCESS_FALLBACK"),
+		},
 	}
-	line := n.createRankingData("今日のpv数ランキング", "#4286f4", data)
-	post = append(post, line)
 
-	month := time.Now().AddDate(0, 0, -(time.Now().Day() - 1)).Format("2006-01-02")
-	data, err = adp.GetSessions(month, today)
-	if err != nil {
-		return err
+	ranges := []struct {
+		title string
+		color string
+		start string
+		end   string
+	}{
+		{"今日のpv数ランキング", "#4286f4", today, today},
+		{"今月のpv数ランキング", "#dbe031", month, today},
+		{"累計pv数ランキング", "#41a300", "2015-08-14", today},
 	}
-	line = n.createRankingData("今月のpv数ランキング", "#dbe031", data)
-	post = append(post, line)
 
-	data, err = adp.GetSessions("2015-08-14", today)
-	if err != nil {
-		return err
+	for _, r := range ranges {
+		data, err := n.analytics.GetSessions(ctx, r.start, r.end)
+		if err != nil {
+			return fmt.Errorf("get sessions (%s): %w", r.title, err)
+		}
+		posts = append(posts, n.createRankingData(r.title, r.color, data))
 	}
-	line = n.createRankingData("累計pv数ランキング", "#41a300", data)
-	post = append(post, line)
 
-	slack := repository.NewSlackRepository()
-	err = slack.Post(os.Getenv("SUCCESS_WEBHOOK_URL"), post)
-	if err != nil {
-		return err
+	if err := n.slack.Post(ctx, os.Getenv("SUCCESS_WEBHOOK_URL"), posts); err != nil {
+		return fmt.Errorf("post to slack: %w", err)
 	}
 
 	return nil
 }
 
-func (n *notifyImpl) Error(err error) {
-	slack := repository.NewSlackRepository()
+func (n *notifyImpl) Error(ctx context.Context, err error) {
+	slog.ErrorContext(ctx, "notify failed", slog.Any("error", err))
 
-	post := []*repository.Post{}
-	post = append(post, &repository.Post{
-		Fallback: os.Getenv("FAILD_FALLBACK"),
-		Pretext:  "<@" + os.Getenv("SLACK_ID") + "> " + os.Getenv("FAILD_FALLBACK"),
-		Title:    err.Error(),
-		Color:    "#EB4646",
-		Footer:   "analytics_notifications_slack",
-	})
+	posts := []*repository.Post{
+		{
+			Fallback: os.Getenv("FAILD_FALLBACK"),
+			Pretext:  "<@" + os.Getenv("SLACK_ID") + "> " + os.Getenv("FAILD_FALLBACK"),
+			Title:    err.Error(),
+			Color:    "#EB4646",
+			Footer:   "analytics_notifications_slack",
+		},
+	}
 
-	_ = slack.Post(os.Getenv("FAILD_WEBHOOK_URL"), post)
-	fmt.Print(err)
+	if postErr := n.slack.Post(ctx, os.Getenv("FAILD_WEBHOOK_URL"), posts); postErr != nil {
+		slog.ErrorContext(ctx, "failed to post error to slack", slog.Any("error", postErr))
+	}
 }
 
 func (n *notifyImpl) createRankingData(title string, color string, data []*repository.Page) *repository.Post {
@@ -87,11 +93,10 @@ func (n *notifyImpl) createRankingData(title string, color string, data []*repos
 		}
 		text = append(text, fmt.Sprintf("[%d] <https://%s|%s>: %dpv", i+1, item.Path, item.Title, item.PV))
 	}
-	post := &repository.Post{
+
+	return &repository.Post{
 		Title: title,
 		Text:  strings.Join(text, "\n"),
 		Color: color,
 	}
-
-	return post
 }

--- a/usecase/notify.go
+++ b/usecase/notify.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/limit7412/analytics_notifications_slack/repository"
+	"golang.org/x/sync/errgroup"
 )
 
 type NotifyUsecase interface {
@@ -34,13 +35,6 @@ func (n *notifyImpl) Run(ctx context.Context) error {
 	today := now.Format("2006-01-02")
 	month := now.AddDate(0, 0, -(now.Day() - 1)).Format("2006-01-02")
 
-	posts := []*repository.Post{
-		{
-			Fallback: os.Getenv("SUCCESS_FALLBACK"),
-			Pretext:  os.Getenv("SUCCESS_FALLBACK"),
-		},
-	}
-
 	ranges := []struct {
 		title string
 		color string
@@ -52,13 +46,30 @@ func (n *notifyImpl) Run(ctx context.Context) error {
 		{"累計pv数ランキング", "#41a300", "2015-08-14", today},
 	}
 
-	for _, r := range ranges {
-		data, err := n.analytics.GetSessions(ctx, r.start, r.end)
-		if err != nil {
-			return fmt.Errorf("get sessions (%s): %w", r.title, err)
-		}
-		posts = append(posts, n.createRankingData(r.title, r.color, data))
+	// Fetch each date range concurrently; results are stored by index to
+	// preserve the original ordering.
+	rankings := make([]*repository.Post, len(ranges))
+	g, ctx := errgroup.WithContext(ctx)
+	for i, r := range ranges {
+		g.Go(func() error {
+			data, err := n.analytics.GetSessions(ctx, r.start, r.end)
+			if err != nil {
+				return fmt.Errorf("get sessions (%s): %w", r.title, err)
+			}
+			rankings[i] = n.createRankingData(r.title, r.color, data)
+			return nil
+		})
 	}
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	posts := make([]*repository.Post, 0, len(ranges)+1)
+	posts = append(posts, &repository.Post{
+		Fallback: os.Getenv("SUCCESS_FALLBACK"),
+		Pretext:  os.Getenv("SUCCESS_FALLBACK"),
+	})
+	posts = append(posts, rankings...)
 
 	if err := n.slack.Post(ctx, os.Getenv("SUCCESS_WEBHOOK_URL"), posts); err != nil {
 		return fmt.Errorf("post to slack: %w", err)
@@ -80,7 +91,12 @@ func (n *notifyImpl) Error(ctx context.Context, err error) {
 		},
 	}
 
-	if postErr := n.slack.Post(ctx, os.Getenv("FAILD_WEBHOOK_URL"), posts); postErr != nil {
+	// Use a detached context so the failure notification is still delivered
+	// even when the incoming ctx was already cancelled (e.g. Lambda timeout).
+	notifyCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+	defer cancel()
+
+	if postErr := n.slack.Post(notifyCtx, os.Getenv("FAILD_WEBHOOK_URL"), posts); postErr != nil {
 		slog.ErrorContext(ctx, "failed to post error to slack", slog.Any("error", postErr))
 	}
 }

--- a/usecase/notify.go
+++ b/usecase/notify.go
@@ -47,11 +47,13 @@ func (n *notifyImpl) Run(ctx context.Context) error {
 	}
 
 	// 各期間を並列に取得する。結果はインデックスで格納し、元の順序を保持する。
+	// errgroup の派生 ctx (gctx) は Wait 後にキャンセルされるため取得処理にのみ使い、
+	// 成功通知には元の ctx を使う。
 	rankings := make([]*repository.Post, len(ranges))
-	g, ctx := errgroup.WithContext(ctx)
+	g, gctx := errgroup.WithContext(ctx)
 	for i, r := range ranges {
 		g.Go(func() error {
-			data, err := n.analytics.GetSessions(ctx, r.start, r.end)
+			data, err := n.analytics.GetSessions(gctx, r.start, r.end)
 			if err != nil {
 				return fmt.Errorf("get sessions (%s): %w", r.title, err)
 			}


### PR DESCRIPTION
## 概要

最新Go対応の **フェーズ2**。モダンな Go イディオムへのリファクタリング。

> ⚠️ このPRは #フェーズ1 をベースにスタックしています。フェーズ1のマージ後に base を master へ切り替えてください。

関連 issue: #59

## 変更内容

- **context 伝播**: `Handler(ctx)` の `ctx` を usecase → repository まで貫通させ、Lambda のタイムアウト/キャンセルに連動（従来は `context.Background()` を都度生成して握り潰していた）
- **DI 化**: repository をメソッド内で都度 `New...()` していたのをやめ、コンストラクタ注入に変更（テスト可能化）
- **analytics**: サービス生成を 1 実行 3 回 → コンストラクタで 1 回のみに。`sort.Slice`→`slices.SortFunc`+`cmp`、map 走査→`slices.Collect`/`maps.Values`、エラーを `%w` でラップ
- **slack**: `http.PostForm`（タイムアウト無し・ctx 無し）→ `http.NewRequestWithContext` + タイムアウト付き `http.Client`。非2xx ステータスをエラー化、body の drain 追加、デバッグ用 `fmt.Print` 削除
- **usecase**: `fmt.Print`→`log/slog`（構造化ログ）、`time.Now()` を集約、日付レンジをテーブル化
- **handler**: 不自然な `Response = events.CloudWatchEvent` 型エイリアスを廃止。エラーを握り潰さず Lambda へ返却し失敗を可視化

## 確認

- [x] `go build ./...` / Lambda 向けクロスビルド
- [x] `go vet ./...`

## 注意点

handler がエラーを Lambda へ返却するようになったため、スケジュール実行が失敗扱いになり EventBridge のリトライ/メトリクスに反映されます（意図的な可視化）。


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vm97zWBuKdkHfCjxGLw5Nt)_