### PR TITLE
[フェーズ3] ユニットテストとCIテストワークフローを追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: checkout
+        uses: actions/checkout@v5
+
+      - name: setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: vet
+        run: go vet ./...
+
+      - name: test
+        run: go test -race ./...

--- a/repository/analytics_test.go
+++ b/repository/analytics_test.go
@@ -1,0 +1,140 @@
+package repository
+
+import (
+	"testing"
+
+	analytics "google.golang.org/api/analyticsdata/v1beta"
+)
+
+func row(title, host, path, pv string) *analytics.Row {
+	return &analytics.Row{
+		DimensionValues: []*analytics.DimensionValue{
+			{Value: title},
+			{Value: host},
+			{Value: path},
+		},
+		MetricValues: []*analytics.MetricValue{
+			{Value: pv},
+		},
+	}
+}
+
+func TestAggregateRows(t *testing.T) {
+	tests := []struct {
+		name       string
+		rows       []*analytics.Row
+		titleSplit string
+		want       map[string]int // title -> PV
+		wantPath   map[string]string
+		wantErr    bool
+	}{
+		{
+			name: "sums PV for duplicate titles",
+			rows: []*analytics.Row{
+				row("記事A | サイト", "example.com", "/blog/a", "10"),
+				row("記事A | サイト", "example.com", "/blog/a", "5"),
+			},
+			titleSplit: " | ",
+			want:       map[string]int{"記事A": 15},
+			wantPath:   map[string]string{"記事A": "example.com/blog/a"},
+		},
+		{
+			name: "skips top-level path",
+			rows: []*analytics.Row{
+				row("トップ", "example.com", "/", "100"),
+				row("記事B", "example.com", "/blog/b", "3"),
+			},
+			titleSplit: " | ",
+			want:       map[string]int{"記事B": 3},
+		},
+		{
+			name: "splits title on separator",
+			rows: []*analytics.Row{
+				row("見出し - サイト名", "example.com", "/blog/c", "7"),
+			},
+			titleSplit: " - ",
+			want:       map[string]int{"見出し": 7},
+		},
+		{
+			name:       "non-numeric PV is an error",
+			rows:       []*analytics.Row{row("記事C", "example.com", "/blog/d", "abc")},
+			titleSplit: " | ",
+			wantErr:    true,
+		},
+		{
+			name:       "empty titleSplit keeps the full title without panicking",
+			rows:       []*analytics.Row{row("記事D", "example.com", "/blog/e", "4")},
+			titleSplit: "",
+			want:       map[string]int{"記事D": 4},
+		},
+		{
+			name:       "empty title with empty titleSplit does not panic",
+			rows:       []*analytics.Row{row("", "example.com", "/blog/f", "2")},
+			titleSplit: "",
+			want:       map[string]int{"": 2},
+		},
+		{
+			name: "skips malformed rows",
+			rows: []*analytics.Row{
+				nil,
+				{DimensionValues: []*analytics.DimensionValue{{Value: "x"}}}, // too few dimensions
+				row("記事E", "example.com", "/blog/g", "9"),
+			},
+			titleSplit: " | ",
+			want:       map[string]int{"記事E": 9},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pageMap := make(map[string]*Page)
+			err := aggregateRows(pageMap, tt.rows, tt.titleSplit)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			for title, pv := range tt.want {
+				p, ok := pageMap[title]
+				if !ok {
+					t.Fatalf("title %q missing from result", title)
+				}
+				if p.PV != pv {
+					t.Errorf("title %q PV = %d, want %d", title, p.PV, pv)
+				}
+			}
+			for title, path := range tt.wantPath {
+				if got := pageMap[title].Path; got != path {
+					t.Errorf("title %q Path = %q, want %q", title, got, path)
+				}
+			}
+			if len(pageMap) != len(tt.want) {
+				t.Errorf("got %d pages, want %d", len(pageMap), len(tt.want))
+			}
+		})
+	}
+}
+
+func TestSortPages(t *testing.T) {
+	pageMap := map[string]*Page{
+		"low":  {Title: "low", PV: 1},
+		"high": {Title: "high", PV: 100},
+		"mid":  {Title: "mid", PV: 50},
+	}
+
+	got := sortPages(pageMap)
+
+	want := []string{"high", "mid", "low"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d pages, want %d", len(got), len(want))
+	}
+	for i, title := range want {
+		if got[i].Title != title {
+			t.Errorf("position %d = %q, want %q", i, got[i].Title, title)
+		}
+	}
+}

--- a/repository/analytics_test.go
+++ b/repository/analytics_test.go
@@ -24,7 +24,7 @@ func TestAggregateRows(t *testing.T) {
 		name       string
 		rows       []*analytics.Row
 		titleSplit string
-		want       map[string]int // title -> PV
+		want       map[string]int // タイトル -> PV
 		wantPath   map[string]string
 		wantErr    bool
 	}{
@@ -77,7 +77,7 @@ func TestAggregateRows(t *testing.T) {
 			name: "skips malformed rows",
 			rows: []*analytics.Row{
 				nil,
-				{DimensionValues: []*analytics.DimensionValue{{Value: "x"}}}, // too few dimensions
+				{DimensionValues: []*analytics.DimensionValue{{Value: "x"}}}, // ディメンション不足
 				row("記事E", "example.com", "/blog/g", "9"),
 			},
 			titleSplit: " | ",

--- a/usecase/notify_test.go
+++ b/usecase/notify_test.go
@@ -25,14 +25,16 @@ func (f *fakeAnalytics) GetSessions(_ context.Context, _ string, _ string) ([]*r
 }
 
 type fakeSlack struct {
-	posts [][]*repository.Post
-	paths []string
-	err   error
+	posts    [][]*repository.Post
+	paths    []string
+	postErrs []error // Post 呼び出し時点の ctx.Err()
+	err      error
 }
 
-func (f *fakeSlack) Post(_ context.Context, path string, msg []*repository.Post) error {
+func (f *fakeSlack) Post(ctx context.Context, path string, msg []*repository.Post) error {
 	f.paths = append(f.paths, path)
 	f.posts = append(f.posts, msg)
+	f.postErrs = append(f.postErrs, ctx.Err())
 	return f.err
 }
 
@@ -89,6 +91,11 @@ func TestRunSuccess(t *testing.T) {
 	}
 	if slack.paths[0] != "https://hooks.example/success" {
 		t.Errorf("posted to %q", slack.paths[0])
+	}
+	// 成功通知には、errgroup の Wait 後にキャンセルされる派生 ctx ではなく
+	// 有効な ctx が渡されなければならない。
+	if slack.postErrs[0] != nil {
+		t.Errorf("slack.Post received a cancelled context: %v", slack.postErrs[0])
 	}
 	// 先頭のフォールバック + 3つのランキング添付が順番通りに並ぶ。
 	if got := len(slack.posts[0]); got != 4 {

--- a/usecase/notify_test.go
+++ b/usecase/notify_test.go
@@ -48,7 +48,7 @@ func TestCreateRankingData(t *testing.T) {
 	if post.Title != "ランキング" || post.Color != "#fff" {
 		t.Errorf("unexpected title/color: %+v", post)
 	}
-	// Only the top 5 entries should be rendered.
+	// 上位5件のみが描画される。
 	if lines := strings.Count(post.Text, "\n") + 1; lines != 5 {
 		t.Errorf("got %d lines, want 5", lines)
 	}
@@ -80,7 +80,7 @@ func TestRunSuccess(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// One call per date range (today, month, cumulative), run concurrently.
+	// 期間(今日・今月・累計)ごとに1回ずつ、並列に呼び出される。
 	if got := analytics.calls.Load(); got != 3 {
 		t.Errorf("GetSessions called %d times, want 3", got)
 	}
@@ -90,7 +90,7 @@ func TestRunSuccess(t *testing.T) {
 	if slack.paths[0] != "https://hooks.example/success" {
 		t.Errorf("posted to %q", slack.paths[0])
 	}
-	// Fallback header + 3 ranking attachments, in order.
+	// 先頭のフォールバック + 3つのランキング添付が順番通りに並ぶ。
 	if got := len(slack.posts[0]); got != 4 {
 		t.Fatalf("attachments = %d, want 4", got)
 	}
@@ -125,7 +125,7 @@ func TestError(t *testing.T) {
 	slack := &fakeSlack{}
 	n := NewNotifyUsecase(&fakeAnalytics{}, slack)
 
-	// Even with an already-cancelled context the notification must be sent.
+	// 既にキャンセル済みのコンテキストでも通知は送られなければならない。
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	n.Error(ctx, errors.New("something broke"))

--- a/usecase/notify_test.go
+++ b/usecase/notify_test.go
@@ -1,0 +1,146 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/limit7412/analytics_notifications_slack/repository"
+)
+
+type fakeAnalytics struct {
+	pages []*repository.Page
+	err   error
+	calls atomic.Int64
+}
+
+func (f *fakeAnalytics) GetSessions(_ context.Context, _ string, _ string) ([]*repository.Page, error) {
+	f.calls.Add(1)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.pages, nil
+}
+
+type fakeSlack struct {
+	posts [][]*repository.Post
+	paths []string
+	err   error
+}
+
+func (f *fakeSlack) Post(_ context.Context, path string, msg []*repository.Post) error {
+	f.paths = append(f.paths, path)
+	f.posts = append(f.posts, msg)
+	return f.err
+}
+
+func TestCreateRankingData(t *testing.T) {
+	n := &notifyImpl{}
+	pages := make([]*repository.Page, 0, 7)
+	for i := 0; i < 7; i++ {
+		pages = append(pages, &repository.Page{Title: "t", Path: "h/p", PV: i})
+	}
+
+	post := n.createRankingData("ランキング", "#fff", pages)
+
+	if post.Title != "ランキング" || post.Color != "#fff" {
+		t.Errorf("unexpected title/color: %+v", post)
+	}
+	// Only the top 5 entries should be rendered.
+	if lines := strings.Count(post.Text, "\n") + 1; lines != 5 {
+		t.Errorf("got %d lines, want 5", lines)
+	}
+	if !strings.Contains(post.Text, "[1] <https://h/p|t>: 0pv") {
+		t.Errorf("unexpected first line: %q", post.Text)
+	}
+}
+
+func TestCreateRankingDataFewerThanFive(t *testing.T) {
+	n := &notifyImpl{}
+	pages := []*repository.Page{{Title: "a", Path: "h/a", PV: 3}}
+
+	post := n.createRankingData("t", "#000", pages)
+
+	if post.Text != "[1] <https://h/a|a>: 3pv" {
+		t.Errorf("unexpected text: %q", post.Text)
+	}
+}
+
+func TestRunSuccess(t *testing.T) {
+	t.Setenv("SUCCESS_WEBHOOK_URL", "https://hooks.example/success")
+	t.Setenv("SUCCESS_FALLBACK", "ok")
+
+	analytics := &fakeAnalytics{pages: []*repository.Page{{Title: "a", Path: "h/a", PV: 1}}}
+	slack := &fakeSlack{}
+	n := NewNotifyUsecase(analytics, slack)
+
+	if err := n.Run(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// One call per date range (today, month, cumulative), run concurrently.
+	if got := analytics.calls.Load(); got != 3 {
+		t.Errorf("GetSessions called %d times, want 3", got)
+	}
+	if len(slack.posts) != 1 {
+		t.Fatalf("slack posted %d times, want 1", len(slack.posts))
+	}
+	if slack.paths[0] != "https://hooks.example/success" {
+		t.Errorf("posted to %q", slack.paths[0])
+	}
+	// Fallback header + 3 ranking attachments, in order.
+	if got := len(slack.posts[0]); got != 4 {
+		t.Fatalf("attachments = %d, want 4", got)
+	}
+	wantTitles := []string{"", "今日のpv数ランキング", "今月のpv数ランキング", "累計pv数ランキング"}
+	for i, want := range wantTitles {
+		if got := slack.posts[0][i].Title; got != want {
+			t.Errorf("attachment %d title = %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestRunAnalyticsError(t *testing.T) {
+	wantErr := errors.New("boom")
+	analytics := &fakeAnalytics{err: wantErr}
+	slack := &fakeSlack{}
+	n := NewNotifyUsecase(analytics, slack)
+
+	err := n.Run(context.Background())
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want wrap of %v", err, wantErr)
+	}
+	if len(slack.posts) != 0 {
+		t.Errorf("slack should not be posted on analytics failure")
+	}
+}
+
+func TestError(t *testing.T) {
+	t.Setenv("FAILD_WEBHOOK_URL", "https://hooks.example/fail")
+	t.Setenv("FAILD_FALLBACK", "failed")
+	t.Setenv("SLACK_ID", "U123")
+
+	slack := &fakeSlack{}
+	n := NewNotifyUsecase(&fakeAnalytics{}, slack)
+
+	// Even with an already-cancelled context the notification must be sent.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	n.Error(ctx, errors.New("something broke"))
+
+	if len(slack.posts) != 1 {
+		t.Fatalf("slack posted %d times, want 1", len(slack.posts))
+	}
+	if slack.paths[0] != "https://hooks.example/fail" {
+		t.Errorf("posted to %q", slack.paths[0])
+	}
+	post := slack.posts[0][0]
+	if post.Title != "something broke" {
+		t.Errorf("title = %q", post.Title)
+	}
+	if !strings.Contains(post.Pretext, "<@U123>") {
+		t.Errorf("pretext missing mention: %q", post.Pretext)
+	}
+}


### PR DESCRIPTION
## 概要

最新Go対応の **フェーズ3**。フェーズ2のDI化を活かしたユニットテストとCIの整備。

> ⚠️ このPRは #フェーズ2 をベースにスタックしています。フェーズ2のマージ後に base を切り替えてください。

関連 issue: #59

## 変更内容

- **analytics**: 行集計ロジックを `aggregateRows`/`sortPages` に抽出し table-driven テスト（PV合算・トップレベルパス除外・タイトル分割・数値変換エラー・降順ソート）
- **usecase**: モック注入で `Run`/`Error`/`createRankingData` をテスト
- `.github/workflows/test.yml`: PR/push 時に `go vet` と `go test` を実行

## 確認

- [x] `go test ./...`
- [x] `go vet ./...`


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vm97zWBuKdkHfCjxGLw5Nt)_