### PR TITLE
fix: スケジュール時刻に Slack へ投稿されない問題を修正

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -13,12 +13,21 @@ provider:
 plugins:
   - serverless-plugin-scripts
 
+# スケジュール実行は prod ステージでのみ有効にする。
+# それ以外のステージ(dev等)ではルールはデプロイされるが無効化される。
+# ステージごとの値は params で定義する。
+# (custom + 動的キー(scheduleEnabled.${sls:stage}) + 変数参照では serverless v4 で
+#  enabled に boolean がそのまま渡らず、prod でも EventBridge ルールが DISABLED の
+#  まま作成されてスケジュール実行されなかった。params はステージごとに値を重ね、
+#  boolean 型を保持したまま enabled へ渡せる。)
+params:
+  default:
+    scheduleEnabled: false
+  prod:
+    scheduleEnabled: true
+
 custom:
   defaultStage: dev
-  # スケジュール実行は prod ステージでのみ有効にする。
-  # それ以外のステージ(dev等)ではデプロイされるが EventBridge ルールは無効化される。
-  scheduleEnabled:
-    prod: true
   scripts:
     hooks:
       # ローカルでのビルド時に bootstrap を生成する
@@ -36,4 +45,4 @@ functions:
     events:
       - schedule:
           rate: cron(0 8 * * ? *) # UTC
-          enabled: ${self:custom.scheduleEnabled.${sls:stage}, false}
+          enabled: ${param:scheduleEnabled}

--- a/serverless.yml
+++ b/serverless.yml
@@ -16,10 +16,6 @@ plugins:
 # スケジュール実行は prod ステージでのみ有効にする。
 # それ以外のステージ(dev等)ではルールはデプロイされるが無効化される。
 # ステージごとの値は params で定義する。
-# (custom + 動的キー(scheduleEnabled.${sls:stage}) + 変数参照では serverless v4 で
-#  enabled に boolean がそのまま渡らず、prod でも EventBridge ルールが DISABLED の
-#  まま作成されてスケジュール実行されなかった。params はステージごとに値を重ね、
-#  boolean 型を保持したまま enabled へ渡せる。)
 params:
   default:
     scheduleEnabled: false


### PR DESCRIPTION
## 概要

スケジュール時刻になっても Slack へ投稿されない不具合を調査し修正しました。

## 原因

直近の `fb3455d`（「スケジュール実行をステージごとに制御し、実行時刻を更新」）で `schedule.enabled` を以下のように指定していました。

```yaml
enabled: ${self:custom.scheduleEnabled.${sls:stage}, false}
```

prod へのデプロイ自体は成功していました（`9dfe5cd` のデプロイは success）が、スケジュール時刻に投稿されない＝**EventBridge ルールが DISABLED のまま作成されていた**状態でした。

この指定は serverless v4（CI が `npm i -g serverless` で導入するバージョン）では脆く、次の2点が組み合わさっています。

1. **動的に組み立てた入れ子キー** `scheduleEnabled.${sls:stage}` のルックアップ
2. **変数参照の結果を `enabled`（boolean）へ渡す**

変数経由で `enabled` を渡すと boolean として扱われない既知の挙動（[serverless/serverless#5379](https://github.com/serverless/serverless/issues/5379) と同種）があり、加えて動的キーのルックアップが既定値 `false` に落ちることで、**prod でもルールが無効化**されていました。

## 修正

ステージごとの値を Serverless v4 の **stage params** で定義し、boolean 型を保持したまま `enabled` へ渡すように変更しました。動的キーも変数→boolean の曖昧さも解消されます。

```yaml
params:
  default:
    scheduleEnabled: false
  prod:
    scheduleEnabled: true
...
      - schedule:
          rate: cron(0 8 * * ? *) # UTC
          enabled: ${param:scheduleEnabled}
```

- prod: `enabled: true`（ENABLED）→ スケジュール実行される
- dev 等: `enabled: false`（DISABLED）→ ルールはデプロイされるが無効

## 確認

- `serverless.yml` の YAML 構文チェック: OK
- `go vet ./...` / `go test ./...`: いずれも pass

## 補足

serverless v4 はバイナリ配布（コア非公開）かつ本環境ではリリース取得が 403 となり、ローカルでの `sls print` による解決結果の実機確認はできませんでした。デプロイ成功にもかかわらずスケジュールが発火しない症状は、`enabled` が prod で無効化されていたことと整合します。マージ後の prod デプロイで EventBridge ルールが `ENABLED` になることをご確認ください。

https://claude.ai/code/session_01PnyZJ5qR3h7LaA5jGxsnNC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnyZJ5qR3h7LaA5jGxsnNC)_