### PR TITLE
feat: NOTIFY_MODE=discord でDiscordへ投稿できるモードを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ googleアナリティクスのpvを集計してランキングを作成して投
   SUCCESS_FALLBACK: <投稿時に通知に表示するテキスト>
   FAILD_WEBHOOK_URL: <エラー時に通知をするwebhook>
   FAILD_FALLBACK: <エラーを投稿すつ際に通知に表示するテキスト>
-  MENTION_ID: <エラー時に通知(メンション)をするユーザーid。未設定時は SLACK_ID にフォールバック>
-  SLACK_ID: <エラー時に通知をするslackのユーザーid(後方互換用。MENTION_ID を推奨)>
   TITLE_SPLIT: <ここに指定した文字列以降を無視する>
 ```
 
-discordモードの場合は `SUCCESS_WEBHOOK_URL` / `FAILD_WEBHOOK_URL` にdiscordのwebhook URLを、`MENTION_ID` にdiscordのユーザーidを設定する
+エラー時は全体通知(slack: `@channel`、discord: `@everyone`)でメンションされる
+
+discordモードの場合は `SUCCESS_WEBHOOK_URL` / `FAILD_WEBHOOK_URL` にdiscordのwebhook URLを設定する

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 googleアナリティクスのpvを集計してランキングを作成して投稿するslackbot
 
+`NOTIFY_MODE: discord` を設定するとエラー通知(Alert)も含めてdiscordへ投稿できる
+
 ## deploy
   - 事前にserverlessからawsに接続を確立する
   - serverless-plugin-scripts をインストール
@@ -19,10 +21,14 @@ googleアナリティクスのpvを集計してランキングを作成して投
 ```
   GOOGLE_APPLICATION_CREDENTIALS: secret.json
   PROFILE_ID: <対象にしたいgoogleアナリティクスのプロファイルID>
+  NOTIFY_MODE: <投稿先。slack または discord。未設定時は slack>
   SUCCESS_WEBHOOK_URL: <集計結果を投稿するwebhook>
   SUCCESS_FALLBACK: <投稿時に通知に表示するテキスト>
   FAILD_WEBHOOK_URL: <エラー時に通知をするwebhook>
   FAILD_FALLBACK: <エラーを投稿すつ際に通知に表示するテキスト>
-  SLACK_ID: <エラー時に通知をするslackのユーザーid>
+  MENTION_ID: <エラー時に通知(メンション)をするユーザーid。未設定時は SLACK_ID にフォールバック>
+  SLACK_ID: <エラー時に通知をするslackのユーザーid(後方互換用。MENTION_ID を推奨)>
   TITLE_SPLIT: <ここに指定した文字列以降を無視する>
 ```
+
+discordモードの場合は `SUCCESS_WEBHOOK_URL` / `FAILD_WEBHOOK_URL` にdiscordのwebhook URLを、`MENTION_ID` にdiscordのユーザーidを設定する

--- a/handler/main.go
+++ b/handler/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/limit7412/analytics_notifications_slack/repository"
@@ -12,7 +13,7 @@ import (
 // リポジトリは遅延初期化し、Lambda のウォームスタート間でキャッシュ・再利用する
 // ことで、呼び出しごとの接続・認証情報の再確立コストを避ける。
 var (
-	slackRepo     repository.SlackRepository
+	notifyRepo    repository.NotifyRepository
 	analyticsRepo repository.AnalyticsRepository
 )
 
@@ -22,11 +23,20 @@ type Response struct {
 	Message string `json:"message"`
 }
 
+// newNotifyRepository は NOTIFY_MODE(slack | discord、未設定時は slack)に
+// 応じた通知先リポジトリを生成する。
+func newNotifyRepository() repository.NotifyRepository {
+	if os.Getenv("NOTIFY_MODE") == "discord" {
+		return repository.NewDiscordRepository()
+	}
+	return repository.NewSlackRepository()
+}
+
 // Handler は `lambda.Start` から呼び出される Lambda ハンドラー。
 // スケジュール(EventBridge)起動のため、入力ペイロードは受け取らない。
 func Handler(ctx context.Context) (Response, error) {
-	if slackRepo == nil {
-		slackRepo = repository.NewSlackRepository()
+	if notifyRepo == nil {
+		notifyRepo = newNotifyRepository()
 	}
 
 	if analyticsRepo == nil {
@@ -35,14 +45,14 @@ func Handler(ctx context.Context) (Response, error) {
 		repo, err := repository.NewAnalyticsRepository(context.Background())
 		if err != nil {
 			err = fmt.Errorf("init analytics repository: %w", err)
-			// slackRepo は生成済みなので、この経路でも失敗通知を送る。
-			usecase.NewNotifyUsecase(nil, slackRepo).Error(ctx, err)
+			// notifyRepo は生成済みなので、この経路でも失敗通知を送る。
+			usecase.NewNotifyUsecase(nil, notifyRepo).Error(ctx, err)
 			return Response{}, err
 		}
 		analyticsRepo = repo
 	}
 
-	app := usecase.NewNotifyUsecase(analyticsRepo, slackRepo)
+	app := usecase.NewNotifyUsecase(analyticsRepo, notifyRepo)
 	if err := app.Run(ctx); err != nil {
 		app.Error(ctx, err)
 		return Response{}, err

--- a/repository/discord.go
+++ b/repository/discord.go
@@ -1,0 +1,150 @@
+package repository
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Discord webhook の制約値。
+// https://discord.com/developers/docs/resources/webhook
+const (
+	// 1メッセージあたりの embeds の最大数
+	discordMaxEmbeds = 10
+	// content の最大文字数
+	discordMaxContentLen = 2000
+	// embed description の最大文字数
+	discordMaxDescriptionLen = 4096
+)
+
+type discordImpl struct {
+	client *http.Client
+}
+
+// NewDiscordRepository は Discord へ投稿するリポジトリを生成する
+func NewDiscordRepository() NotifyRepository {
+	return &discordImpl{
+		client: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+type discordFooter struct {
+	Text string `json:"text"`
+}
+
+type discordEmbed struct {
+	Title       string         `json:"title,omitempty"`
+	Description string         `json:"description,omitempty"`
+	Color       int            `json:"color,omitempty"`
+	Footer      *discordFooter `json:"footer,omitempty"`
+}
+
+type discordPayload struct {
+	Content string          `json:"content,omitempty"`
+	Embeds  []*discordEmbed `json:"embeds,omitempty"`
+}
+
+func (a *discordImpl) Post(ctx context.Context, webhookURL string, msgs []*Message) error {
+	// メンションは embed 内では機能しないため content に出力する。
+	// pretext 相当のテキストも embed には対応する場所がないので content にまとめる。
+	contentParts := []string{}
+	mentioned := false
+	embeds := []*discordEmbed{}
+	for _, msg := range msgs {
+		if msg.Mention && !mentioned {
+			contentParts = append(contentParts, "<@"+mentionID()+">")
+			mentioned = true
+		}
+		if msg.Pretext != "" {
+			contentParts = append(contentParts, msg.Pretext)
+		}
+		if msg.Title == "" && msg.Text == "" && msg.Footer == "" {
+			continue
+		}
+
+		var footer *discordFooter
+		if msg.Footer != "" {
+			footer = &discordFooter{Text: msg.Footer}
+		}
+		embeds = append(embeds, &discordEmbed{
+			Title:       msg.Title,
+			Description: truncateRunes(msg.Text, discordMaxDescriptionLen),
+			Color:       hexToColor(msg.Color),
+			Footer:      footer,
+		})
+	}
+
+	content := truncateRunes(strings.Join(contentParts, " "), discordMaxContentLen)
+	if content == "" && len(embeds) == 0 {
+		return nil
+	}
+
+	// embeds は1メッセージ最大10件のため、超える場合はチャンクして複数回送信する。
+	// content は先頭のメッセージにのみ載せる。
+	for first := true; first || len(embeds) > 0; first = false {
+		chunk := embeds[:min(len(embeds), discordMaxEmbeds)]
+		embeds = embeds[len(chunk):]
+
+		payload := &discordPayload{Embeds: chunk}
+		if first {
+			payload.Content = content
+		}
+		if err := a.post(ctx, webhookURL, payload); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (a *discordImpl) post(ctx context.Context, webhookURL string, payload *discordPayload) error {
+	params, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal discord payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, bytes.NewReader(params))
+	if err != nil {
+		return fmt.Errorf("create discord request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := a.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("post to discord: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		resBody, _ := io.ReadAll(io.LimitReader(res.Body, 1024))
+		return fmt.Errorf("discord returned status %d: %s", res.StatusCode, strings.TrimSpace(string(resBody)))
+	}
+	_, _ = io.Copy(io.Discard, res.Body)
+
+	return nil
+}
+
+// hexToColor は `#4286f4` 形式の hex 文字列を Discord の整数指定へ変換する。
+// 変換できない場合は 0(色指定なし)を返す。
+func hexToColor(hex string) int {
+	c, err := strconv.ParseUint(strings.TrimPrefix(hex, "#"), 16, 32)
+	if err != nil || c > 0xFFFFFF {
+		return 0
+	}
+	return int(c)
+}
+
+// truncateRunes は文字数(rune 数)が limit を超える場合に切り詰める。
+func truncateRunes(s string, limit int) string {
+	runes := []rune(s)
+	if len(runes) <= limit {
+		return s
+	}
+	return string(runes[:limit])
+}

--- a/repository/discord.go
+++ b/repository/discord.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // Discord webhook の制約値。
@@ -19,8 +20,14 @@ const (
 	discordMaxEmbeds = 10
 	// content の最大文字数
 	discordMaxContentLen = 2000
+	// embed title の最大文字数
+	discordMaxTitleLen = 256
 	// embed description の最大文字数
 	discordMaxDescriptionLen = 4096
+	// embed footer text の最大文字数
+	discordMaxFooterLen = 2048
+	// 1メッセージ内の全 embed の文字数合計の上限
+	discordMaxTotalLen = 6000
 )
 
 type discordImpl struct {
@@ -72,13 +79,19 @@ func (a *discordImpl) Post(ctx context.Context, webhookURL string, msgs []*Messa
 			continue
 		}
 
+		title := truncateRunes(msg.Title, discordMaxTitleLen)
 		var footer *discordFooter
+		footerText := ""
 		if msg.Footer != "" {
-			footer = &discordFooter{Text: msg.Footer}
+			footerText = truncateRunes(msg.Footer, discordMaxFooterLen)
+			footer = &discordFooter{Text: footerText}
 		}
+		// 単体の embed でもメッセージ全体の文字数合計上限に収まるよう、
+		// title / footer を差し引いた分まで description を切り詰める。
+		descLimit := min(discordMaxDescriptionLen, discordMaxTotalLen-runeCount(title)-runeCount(footerText))
 		embeds = append(embeds, &discordEmbed{
-			Title:       msg.Title,
-			Description: truncateRunes(msg.Text, discordMaxDescriptionLen),
+			Title:       title,
+			Description: truncateRunes(msg.Text, descLimit),
 			Color:       hexToColor(msg.Color),
 			Footer:      footer,
 		})
@@ -89,13 +102,30 @@ func (a *discordImpl) Post(ctx context.Context, webhookURL string, msgs []*Messa
 		return nil
 	}
 
-	// embeds は1メッセージ最大10件のため、超える場合はチャンクして複数回送信する。
-	// content は先頭のメッセージにのみ載せる。
-	for first := true; first || len(embeds) > 0; first = false {
-		chunk := embeds[:min(len(embeds), discordMaxEmbeds)]
-		embeds = embeds[len(chunk):]
+	// embeds は1メッセージ最大10件・文字数合計最大6000字のため、
+	// 超える場合はチャンクして複数回送信する。content は先頭のメッセージにのみ載せる。
+	chunks := [][]*discordEmbed{}
+	chunk := []*discordEmbed{}
+	chunkLen := 0
+	for _, embed := range embeds {
+		size := embedRuneCount(embed)
+		if len(chunk) > 0 && (len(chunk) >= discordMaxEmbeds || chunkLen+size > discordMaxTotalLen) {
+			chunks = append(chunks, chunk)
+			chunk, chunkLen = nil, 0
+		}
+		chunk = append(chunk, embed)
+		chunkLen += size
+	}
+	if len(chunk) > 0 {
+		chunks = append(chunks, chunk)
+	}
 
-		payload := &discordPayload{Embeds: chunk}
+	for first := true; first || len(chunks) > 0; first = false {
+		payload := &discordPayload{}
+		if len(chunks) > 0 {
+			payload.Embeds = chunks[0]
+			chunks = chunks[1:]
+		}
 		if first {
 			payload.Content = content
 		}
@@ -105,6 +135,15 @@ func (a *discordImpl) Post(ctx context.Context, webhookURL string, msgs []*Messa
 	}
 
 	return nil
+}
+
+// embedRuneCount は embed が文字数合計上限に対して占める文字数を返す。
+func embedRuneCount(e *discordEmbed) int {
+	count := runeCount(e.Title) + runeCount(e.Description)
+	if e.Footer != nil {
+		count += runeCount(e.Footer.Text)
+	}
+	return count
 }
 
 func (a *discordImpl) post(ctx context.Context, webhookURL string, payload *discordPayload) error {
@@ -155,4 +194,9 @@ func truncateRunes(s string, limit int) string {
 		count++
 	}
 	return s
+}
+
+// runeCount は文字数(rune 数)を返す。
+func runeCount(s string) int {
+	return utf8.RuneCountInString(s)
 }

--- a/repository/discord.go
+++ b/repository/discord.go
@@ -57,8 +57,12 @@ func (a *discordImpl) Post(ctx context.Context, webhookURL string, msgs []*Messa
 	mentioned := false
 	embeds := []*discordEmbed{}
 	for _, msg := range msgs {
-		if msg.Mention && !mentioned {
-			contentParts = append(contentParts, "<@"+mentionID()+">")
+		if msg == nil {
+			continue
+		}
+		// ID 未設定時は壊れたメンション `<@>` を出力しない。
+		if id := mentionID(); msg.Mention && !mentioned && id != "" {
+			contentParts = append(contentParts, "<@"+id+">")
 			mentioned = true
 		}
 		if msg.Pretext != "" {
@@ -141,10 +145,14 @@ func hexToColor(hex string) int {
 }
 
 // truncateRunes は文字数(rune 数)が limit を超える場合に切り詰める。
+// []rune への変換によるアロケーションを避けるため、byte offset で走査する。
 func truncateRunes(s string, limit int) string {
-	runes := []rune(s)
-	if len(runes) <= limit {
-		return s
+	count := 0
+	for i := range s {
+		if count == limit {
+			return s[:i]
+		}
+		count++
 	}
-	return string(runes[:limit])
+	return s
 }

--- a/repository/discord.go
+++ b/repository/discord.go
@@ -67,9 +67,8 @@ func (a *discordImpl) Post(ctx context.Context, webhookURL string, msgs []*Messa
 		if msg == nil {
 			continue
 		}
-		// ID 未設定時は壊れたメンション `<@>` を出力しない。
-		if id := mentionID(); msg.Mention && !mentioned && id != "" {
-			contentParts = append(contentParts, "<@"+id+">")
+		if msg.Mention && !mentioned {
+			contentParts = append(contentParts, "@everyone")
 			mentioned = true
 		}
 		if msg.Pretext != "" {

--- a/repository/discord_test.go
+++ b/repository/discord_test.go
@@ -129,6 +129,7 @@ func TestDiscordPostTruncates(t *testing.T) {
 	msgs := []*Message{
 		{Pretext: strings.Repeat("あ", discordMaxContentLen+1)},
 		{Text: strings.Repeat("い", discordMaxDescriptionLen+1)},
+		{Title: strings.Repeat("う", discordMaxTitleLen+1)},
 	}
 
 	repo := NewDiscordRepository()
@@ -141,6 +142,57 @@ func TestDiscordPostTruncates(t *testing.T) {
 	}
 	if got := len([]rune(payloads[0].Embeds[0].Description)); got != discordMaxDescriptionLen {
 		t.Errorf("description length = %d, want %d", got, discordMaxDescriptionLen)
+	}
+	if got := len([]rune(payloads[0].Embeds[1].Title)); got != discordMaxTitleLen {
+		t.Errorf("title length = %d, want %d", got, discordMaxTitleLen)
+	}
+}
+
+func TestDiscordPostFitsSingleEmbedInTotalLimit(t *testing.T) {
+	payloads := []discordPayload{}
+	server := newDiscordTestServer(t, http.StatusNoContent, &payloads)
+	defer server.Close()
+
+	// title + footer が大きい場合、単体でも合計上限に収まるよう description が
+	// さらに切り詰められる。
+	msgs := []*Message{{
+		Title:  strings.Repeat("あ", discordMaxTitleLen),
+		Text:   strings.Repeat("い", discordMaxDescriptionLen),
+		Footer: strings.Repeat("う", discordMaxFooterLen),
+	}}
+
+	repo := NewDiscordRepository()
+	if err := repo.Post(context.Background(), server.URL, msgs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := discordMaxTotalLen - discordMaxTitleLen - discordMaxFooterLen
+	if got := len([]rune(payloads[0].Embeds[0].Description)); got != want {
+		t.Errorf("description length = %d, want %d", got, want)
+	}
+}
+
+func TestDiscordPostChunksByTotalLength(t *testing.T) {
+	payloads := []discordPayload{}
+	server := newDiscordTestServer(t, http.StatusNoContent, &payloads)
+	defer server.Close()
+
+	// 1件あたり約2900字 × 3件。10件以下でも合計6000字を超えないよう分割される。
+	msgs := make([]*Message, 0, 3)
+	for i := 0; i < 3; i++ {
+		msgs = append(msgs, &Message{Title: "t", Text: strings.Repeat("あ", 2900)})
+	}
+
+	repo := NewDiscordRepository()
+	if err := repo.Post(context.Background(), server.URL, msgs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(payloads) != 2 {
+		t.Fatalf("posted %d times, want 2", len(payloads))
+	}
+	if len(payloads[0].Embeds) != 2 || len(payloads[1].Embeds) != 1 {
+		t.Errorf("embeds = %d, %d, want 2, 1", len(payloads[0].Embeds), len(payloads[1].Embeds))
 	}
 }
 

--- a/repository/discord_test.go
+++ b/repository/discord_test.go
@@ -31,8 +31,6 @@ func newDiscordTestServer(t *testing.T, status int, payloads *[]discordPayload) 
 }
 
 func TestDiscordPost(t *testing.T) {
-	t.Setenv("MENTION_ID", "D123")
-
 	payloads := []discordPayload{}
 	server := newDiscordTestServer(t, http.StatusNoContent, &payloads)
 	defer server.Close()
@@ -52,8 +50,8 @@ func TestDiscordPost(t *testing.T) {
 	}
 	p := payloads[0]
 
-	// pretext とメンションは content にまとめられる。
-	if want := "ok <@D123> failed"; p.Content != want {
+	// pretext と全体通知は content にまとめられる。
+	if want := "ok @everyone failed"; p.Content != want {
 		t.Errorf("content = %q, want %q", p.Content, want)
 	}
 	// pretext のみのメッセージは embed にならない。
@@ -72,23 +70,6 @@ func TestDiscordPost(t *testing.T) {
 	}
 	if p.Embeds[1].Footer == nil || p.Embeds[1].Footer.Text != "footer" {
 		t.Errorf("footer = %+v", p.Embeds[1].Footer)
-	}
-}
-
-func TestDiscordPostMentionFallsBackToSlackID(t *testing.T) {
-	t.Setenv("MENTION_ID", "")
-	t.Setenv("SLACK_ID", "U123")
-
-	payloads := []discordPayload{}
-	server := newDiscordTestServer(t, http.StatusNoContent, &payloads)
-	defer server.Close()
-
-	repo := NewDiscordRepository()
-	if err := repo.Post(context.Background(), server.URL, []*Message{{Mention: true, Title: "t"}}); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if payloads[0].Content != "<@U123>" {
-		t.Errorf("content = %q, want %q", payloads[0].Content, "<@U123>")
 	}
 }
 

--- a/repository/discord_test.go
+++ b/repository/discord_test.go
@@ -1,0 +1,191 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newDiscordTestServer は受信した JSON ペイロードを記録するテストサーバーを返す。
+func newDiscordTestServer(t *testing.T, status int, payloads *[]discordPayload) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", ct)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		var p discordPayload
+		if err := json.Unmarshal(body, &p); err != nil {
+			t.Fatalf("unmarshal payload: %v", err)
+		}
+		*payloads = append(*payloads, p)
+		w.WriteHeader(status)
+	}))
+}
+
+func TestDiscordPost(t *testing.T) {
+	t.Setenv("MENTION_ID", "D123")
+
+	payloads := []discordPayload{}
+	server := newDiscordTestServer(t, http.StatusNoContent, &payloads)
+	defer server.Close()
+
+	repo := NewDiscordRepository()
+	msgs := []*Message{
+		{Fallback: "ok", Pretext: "ok"},
+		{Title: "ランキング", Text: "[1] [a](https://h/a): 3pv", Color: "#4286f4"},
+		{Mention: true, Pretext: "failed", Title: "boom", Color: "#EB4646", Footer: "footer"},
+	}
+	if err := repo.Post(context.Background(), server.URL, msgs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(payloads) != 1 {
+		t.Fatalf("posted %d times, want 1", len(payloads))
+	}
+	p := payloads[0]
+
+	// pretext とメンションは content にまとめられる。
+	if want := "ok <@D123> failed"; p.Content != want {
+		t.Errorf("content = %q, want %q", p.Content, want)
+	}
+	// pretext のみのメッセージは embed にならない。
+	if len(p.Embeds) != 2 {
+		t.Fatalf("embeds = %d, want 2", len(p.Embeds))
+	}
+	// markdown リンクはそのまま description に載る。
+	if p.Embeds[0].Description != "[1] [a](https://h/a): 3pv" {
+		t.Errorf("description = %q", p.Embeds[0].Description)
+	}
+	if p.Embeds[0].Color != 0x4286f4 {
+		t.Errorf("color = %d, want %d", p.Embeds[0].Color, 0x4286f4)
+	}
+	if p.Embeds[1].Title != "boom" {
+		t.Errorf("title = %q", p.Embeds[1].Title)
+	}
+	if p.Embeds[1].Footer == nil || p.Embeds[1].Footer.Text != "footer" {
+		t.Errorf("footer = %+v", p.Embeds[1].Footer)
+	}
+}
+
+func TestDiscordPostMentionFallsBackToSlackID(t *testing.T) {
+	t.Setenv("MENTION_ID", "")
+	t.Setenv("SLACK_ID", "U123")
+
+	payloads := []discordPayload{}
+	server := newDiscordTestServer(t, http.StatusNoContent, &payloads)
+	defer server.Close()
+
+	repo := NewDiscordRepository()
+	if err := repo.Post(context.Background(), server.URL, []*Message{{Mention: true, Title: "t"}}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if payloads[0].Content != "<@U123>" {
+		t.Errorf("content = %q, want %q", payloads[0].Content, "<@U123>")
+	}
+}
+
+func TestDiscordPostChunksEmbeds(t *testing.T) {
+	payloads := []discordPayload{}
+	server := newDiscordTestServer(t, http.StatusNoContent, &payloads)
+	defer server.Close()
+
+	msgs := make([]*Message, 0, 11)
+	msgs = append(msgs, &Message{Pretext: "head"})
+	for i := 0; i < 11; i++ {
+		msgs = append(msgs, &Message{Title: "t"})
+	}
+
+	repo := NewDiscordRepository()
+	if err := repo.Post(context.Background(), server.URL, msgs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// embeds は最大10件のため 10 + 1 に分割される。
+	if len(payloads) != 2 {
+		t.Fatalf("posted %d times, want 2", len(payloads))
+	}
+	if len(payloads[0].Embeds) != 10 || len(payloads[1].Embeds) != 1 {
+		t.Errorf("embeds = %d, %d, want 10, 1", len(payloads[0].Embeds), len(payloads[1].Embeds))
+	}
+	// content は先頭のメッセージにのみ載る。
+	if payloads[0].Content != "head" || payloads[1].Content != "" {
+		t.Errorf("content = %q, %q", payloads[0].Content, payloads[1].Content)
+	}
+}
+
+func TestDiscordPostTruncates(t *testing.T) {
+	payloads := []discordPayload{}
+	server := newDiscordTestServer(t, http.StatusNoContent, &payloads)
+	defer server.Close()
+
+	msgs := []*Message{
+		{Pretext: strings.Repeat("あ", discordMaxContentLen+1)},
+		{Text: strings.Repeat("い", discordMaxDescriptionLen+1)},
+	}
+
+	repo := NewDiscordRepository()
+	if err := repo.Post(context.Background(), server.URL, msgs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := len([]rune(payloads[0].Content)); got != discordMaxContentLen {
+		t.Errorf("content length = %d, want %d", got, discordMaxContentLen)
+	}
+	if got := len([]rune(payloads[0].Embeds[0].Description)); got != discordMaxDescriptionLen {
+		t.Errorf("description length = %d, want %d", got, discordMaxDescriptionLen)
+	}
+}
+
+func TestDiscordPostEmptyMessages(t *testing.T) {
+	payloads := []discordPayload{}
+	server := newDiscordTestServer(t, http.StatusNoContent, &payloads)
+	defer server.Close()
+
+	repo := NewDiscordRepository()
+	if err := repo.Post(context.Background(), server.URL, []*Message{{}}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// 空ペイロードは Discord がエラーを返すため送信しない。
+	if len(payloads) != 0 {
+		t.Errorf("posted %d times, want 0", len(payloads))
+	}
+}
+
+func TestDiscordPostErrorStatus(t *testing.T) {
+	payloads := []discordPayload{}
+	server := newDiscordTestServer(t, http.StatusTooManyRequests, &payloads)
+	defer server.Close()
+
+	repo := NewDiscordRepository()
+	err := repo.Post(context.Background(), server.URL, []*Message{{Title: "t"}})
+	if err == nil || !strings.Contains(err.Error(), "429") {
+		t.Fatalf("error = %v, want status 429 error", err)
+	}
+}
+
+func TestHexToColor(t *testing.T) {
+	cases := []struct {
+		hex  string
+		want int
+	}{
+		{"#4286f4", 0x4286f4},
+		{"#EB4646", 0xEB4646},
+		{"4286f4", 0x4286f4},
+		{"", 0},
+		{"#zzzzzz", 0},
+		{"#1234567", 0},
+	}
+	for _, c := range cases {
+		if got := hexToColor(c.hex); got != c.want {
+			t.Errorf("hexToColor(%q) = %d, want %d", c.hex, got, c.want)
+		}
+	}
+}

--- a/repository/notify.go
+++ b/repository/notify.go
@@ -1,0 +1,38 @@
+package repository
+
+import (
+	"context"
+	"os"
+)
+
+// NotifyRepository は通知メッセージを webhook へ投稿するリポジトリの
+// 共通インターフェース。Slack / Discord をアダプタとして差し替えられる。
+type NotifyRepository interface {
+	Post(ctx context.Context, webhookURL string, msgs []*Message) error
+}
+
+// Message は投稿先サービスに依存しない中立な通知メッセージ。
+// リンクは markdown 形式 `[title](url)` で Text に保持し、
+// 必要な変換は各アダプタが行う。
+type Message struct {
+	Fallback string
+	// Mention が true の場合、アダプタが投稿先の形式でメンションを付与する。
+	// メンション先の ID は MENTION_ID(未設定時は SLACK_ID)から解決する。
+	Mention bool
+	Pretext string
+	Title   string
+	Text    string
+	// Color は `#4286f4` 形式の hex 文字列。
+	Color  string
+	Footer string
+}
+
+// mentionID はメンション先のユーザー ID を返す。
+// Slack と Discord で ID 体系が異なるため MENTION_ID に一般化しつつ、
+// 後方互換として未設定時は SLACK_ID にフォールバックする。
+func mentionID() string {
+	if id := os.Getenv("MENTION_ID"); id != "" {
+		return id
+	}
+	return os.Getenv("SLACK_ID")
+}

--- a/repository/notify.go
+++ b/repository/notify.go
@@ -1,9 +1,6 @@
 package repository
 
-import (
-	"context"
-	"os"
-)
+import "context"
 
 // NotifyRepository は通知メッセージを webhook へ投稿するリポジトリの
 // 共通インターフェース。Slack / Discord をアダプタとして差し替えられる。
@@ -16,8 +13,8 @@ type NotifyRepository interface {
 // 必要な変換は各アダプタが行う。
 type Message struct {
 	Fallback string
-	// Mention が true の場合、アダプタが投稿先の形式でメンションを付与する。
-	// メンション先の ID は MENTION_ID(未設定時は SLACK_ID)から解決する。
+	// Mention が true の場合、アダプタが投稿先の形式で全体通知
+	// (Slack: <!channel>、Discord: @everyone)を付与する。
 	Mention bool
 	Pretext string
 	Title   string
@@ -25,14 +22,4 @@ type Message struct {
 	// Color は `#4286f4` 形式の hex 文字列。
 	Color  string
 	Footer string
-}
-
-// mentionID はメンション先のユーザー ID を返す。
-// Slack と Discord で ID 体系が異なるため MENTION_ID に一般化しつつ、
-// 後方互換として未設定時は SLACK_ID にフォールバックする。
-func mentionID() string {
-	if id := os.Getenv("MENTION_ID"); id != "" {
-		return id
-	}
-	return os.Getenv("SLACK_ID")
 }

--- a/repository/slack.go
+++ b/repository/slack.go
@@ -7,26 +7,23 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 )
-
-type SlackRepository interface {
-	Post(ctx context.Context, path string, msg []*Post) error
-}
 
 type slackImpl struct {
 	client *http.Client
 }
 
-// NewSlackRepository は Slack へアクセスするリポジトリを生成する
-func NewSlackRepository() SlackRepository {
+// NewSlackRepository は Slack へ投稿するリポジトリを生成する
+func NewSlackRepository() NotifyRepository {
 	return &slackImpl{
 		client: &http.Client{Timeout: 10 * time.Second},
 	}
 }
 
-type Post struct {
+type attachment struct {
 	Fallback string `json:"fallback"`
 	Pretext  string `json:"pretext"`
 	Title    string `json:"title"`
@@ -35,20 +32,44 @@ type Post struct {
 	Footer   string `json:"footer"`
 }
 
-type payload struct {
-	Attachments []*Post `json:"attachments"`
+type slackPayload struct {
+	Attachments []*attachment `json:"attachments"`
 }
 
-func (a *slackImpl) Post(ctx context.Context, path string, msg []*Post) error {
-	params, err := json.Marshal(payload{
-		Attachments: msg,
+// markdownLink は中立表現のリンク `[title](url)` にマッチする。
+var markdownLink = regexp.MustCompile(`\[([^\]]*)\]\(([^)]+)\)`)
+
+// toMrkdwnLinks は `[title](url)` を Slack mrkdwn 形式 `<url|title>` へ変換する。
+func toMrkdwnLinks(text string) string {
+	return markdownLink.ReplaceAllString(text, "<$2|$1>")
+}
+
+func (a *slackImpl) Post(ctx context.Context, webhookURL string, msgs []*Message) error {
+	attachments := make([]*attachment, 0, len(msgs))
+	for _, msg := range msgs {
+		pretext := msg.Pretext
+		if msg.Mention {
+			pretext = "<@" + mentionID() + "> " + pretext
+		}
+		attachments = append(attachments, &attachment{
+			Fallback: msg.Fallback,
+			Pretext:  pretext,
+			Title:    msg.Title,
+			Text:     toMrkdwnLinks(msg.Text),
+			Color:    msg.Color,
+			Footer:   msg.Footer,
+		})
+	}
+
+	params, err := json.Marshal(slackPayload{
+		Attachments: attachments,
 	})
 	if err != nil {
 		return fmt.Errorf("marshal slack payload: %w", err)
 	}
 
 	body := url.Values{"payload": {string(params)}}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, path, strings.NewReader(body.Encode()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, strings.NewReader(body.Encode()))
 	if err != nil {
 		return fmt.Errorf("create slack request: %w", err)
 	}

--- a/repository/slack.go
+++ b/repository/slack.go
@@ -51,9 +51,8 @@ func (a *slackImpl) Post(ctx context.Context, webhookURL string, msgs []*Message
 			continue
 		}
 		pretext := msg.Pretext
-		// ID 未設定時は壊れたメンション `<@>` を出力しない。
-		if id := mentionID(); msg.Mention && id != "" {
-			pretext = "<@" + id + "> " + pretext
+		if msg.Mention {
+			pretext = "<!channel> " + pretext
 		}
 		attachments = append(attachments, &attachment{
 			Fallback: msg.Fallback,

--- a/repository/slack.go
+++ b/repository/slack.go
@@ -47,9 +47,13 @@ func toMrkdwnLinks(text string) string {
 func (a *slackImpl) Post(ctx context.Context, webhookURL string, msgs []*Message) error {
 	attachments := make([]*attachment, 0, len(msgs))
 	for _, msg := range msgs {
+		if msg == nil {
+			continue
+		}
 		pretext := msg.Pretext
-		if msg.Mention {
-			pretext = "<@" + mentionID() + "> " + pretext
+		// ID 未設定時は壊れたメンション `<@>` を出力しない。
+		if id := mentionID(); msg.Mention && id != "" {
+			pretext = "<@" + id + "> " + pretext
 		}
 		attachments = append(attachments, &attachment{
 			Fallback: msg.Fallback,

--- a/repository/slack_test.go
+++ b/repository/slack_test.go
@@ -10,9 +10,6 @@ import (
 )
 
 func TestSlackPost(t *testing.T) {
-	t.Setenv("MENTION_ID", "")
-	t.Setenv("SLACK_ID", "U123")
-
 	payloads := []slackPayload{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if ct := r.Header.Get("Content-Type"); ct != "application/x-www-form-urlencoded" {
@@ -58,9 +55,9 @@ func TestSlackPost(t *testing.T) {
 	if attachments[1].Color != "#4286f4" {
 		t.Errorf("color = %q", attachments[1].Color)
 	}
-	// Mention フラグは pretext のメンションへ変換される(MENTION_ID 未設定時は SLACK_ID)。
-	if attachments[2].Pretext != "<@U123> failed" {
-		t.Errorf("pretext = %q, want %q", attachments[2].Pretext, "<@U123> failed")
+	// Mention フラグは pretext の全体通知へ変換される。
+	if attachments[2].Pretext != "<!channel> failed" {
+		t.Errorf("pretext = %q, want %q", attachments[2].Pretext, "<!channel> failed")
 	}
 	if attachments[2].Footer != "footer" {
 		t.Errorf("footer = %q", attachments[2].Footer)

--- a/repository/slack_test.go
+++ b/repository/slack_test.go
@@ -1,0 +1,98 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSlackPost(t *testing.T) {
+	t.Setenv("MENTION_ID", "")
+	t.Setenv("SLACK_ID", "U123")
+
+	payloads := []slackPayload{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if ct := r.Header.Get("Content-Type"); ct != "application/x-www-form-urlencoded" {
+			t.Errorf("Content-Type = %q, want application/x-www-form-urlencoded", ct)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		var p slackPayload
+		if err := json.Unmarshal([]byte(r.PostFormValue("payload")), &p); err != nil {
+			t.Fatalf("unmarshal payload: %v", err)
+		}
+		payloads = append(payloads, p)
+	}))
+	defer server.Close()
+
+	repo := NewSlackRepository()
+	msgs := []*Message{
+		{Fallback: "ok", Pretext: "ok"},
+		{Title: "ランキング", Text: "[1] [a](https://h/a): 3pv\n[2] [b](https://h/b): 1pv", Color: "#4286f4"},
+		{Mention: true, Pretext: "failed", Title: "boom", Color: "#EB4646", Footer: "footer"},
+	}
+	if err := repo.Post(context.Background(), server.URL, msgs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(payloads) != 1 {
+		t.Fatalf("posted %d times, want 1", len(payloads))
+	}
+	attachments := payloads[0].Attachments
+	if len(attachments) != 3 {
+		t.Fatalf("attachments = %d, want 3", len(attachments))
+	}
+
+	if attachments[0].Fallback != "ok" || attachments[0].Pretext != "ok" {
+		t.Errorf("unexpected fallback attachment: %+v", attachments[0])
+	}
+	// 中立表現の markdown リンクは Slack mrkdwn 形式へ変換される。
+	wantText := "[1] <https://h/a|a>: 3pv\n[2] <https://h/b|b>: 1pv"
+	if attachments[1].Text != wantText {
+		t.Errorf("text = %q, want %q", attachments[1].Text, wantText)
+	}
+	if attachments[1].Color != "#4286f4" {
+		t.Errorf("color = %q", attachments[1].Color)
+	}
+	// Mention フラグは pretext のメンションへ変換される(MENTION_ID 未設定時は SLACK_ID)。
+	if attachments[2].Pretext != "<@U123> failed" {
+		t.Errorf("pretext = %q, want %q", attachments[2].Pretext, "<@U123> failed")
+	}
+	if attachments[2].Footer != "footer" {
+		t.Errorf("footer = %q", attachments[2].Footer)
+	}
+}
+
+func TestSlackPostErrorStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "invalid_payload", http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	repo := NewSlackRepository()
+	err := repo.Post(context.Background(), server.URL, []*Message{{Title: "t"}})
+	if err == nil || !strings.Contains(err.Error(), "400") {
+		t.Fatalf("error = %v, want status 400 error", err)
+	}
+}
+
+func TestToMrkdwnLinks(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"[a](https://h/a)", "<https://h/a|a>"},
+		{"[1] [a](https://h/a): 3pv", "[1] <https://h/a|a>: 3pv"},
+		{"no link", "no link"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := toMrkdwnLinks(c.in); got != c.want {
+			t.Errorf("toMrkdwnLinks(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/usecase/notify.go
+++ b/usecase/notify.go
@@ -124,11 +124,11 @@ func (n *notifyImpl) createRankingData(title string, color string, data []*repos
 }
 
 // sanitizeLinkTitle は markdown リンク `[title](url)` や Slack mrkdwn `<url|title>` を
-// 壊す文字を、見た目の近い全角文字へ置き換える。
+// 壊す文字を、見た目の近い全角文字(U+FF3B/FF3D/FF1C/FF1E/FF5C)へ置き換える。
 var sanitizeLinkTitle = strings.NewReplacer(
-	"[", "[", "]", "]",
-	"<", "<", ">", ">",
-	"|", "|",
+	"[", "［", "]", "］",
+	"<", "＜", ">", "＞",
+	"|", "｜",
 ).Replace
 
 // sanitizeLinkURL はリンク URL の解釈を途中で打ち切る文字をパーセントエンコードする。

--- a/usecase/notify.go
+++ b/usecase/notify.go
@@ -109,6 +109,9 @@ func (n *notifyImpl) createRankingData(title string, color string, data []*repos
 		if i >= 5 {
 			break
 		}
+		if item == nil {
+			continue
+		}
 		// リンクは中立表現の markdown 形式で保持し、変換は各アダプタに任せる。
 		text = append(text, fmt.Sprintf("[%d] [%s](https://%s): %dpv", i+1, item.Title, item.Path, item.PV))
 	}

--- a/usecase/notify.go
+++ b/usecase/notify.go
@@ -113,7 +113,7 @@ func (n *notifyImpl) createRankingData(title string, color string, data []*repos
 			continue
 		}
 		// リンクは中立表現の markdown 形式で保持し、変換は各アダプタに任せる。
-		text = append(text, fmt.Sprintf("[%d] [%s](https://%s): %dpv", i+1, item.Title, item.Path, item.PV))
+		text = append(text, fmt.Sprintf("[%d] [%s](https://%s): %dpv", i+1, sanitizeLinkTitle(item.Title), sanitizeLinkURL(item.Path), item.PV))
 	}
 
 	return &repository.Message{
@@ -122,3 +122,18 @@ func (n *notifyImpl) createRankingData(title string, color string, data []*repos
 		Color: color,
 	}
 }
+
+// sanitizeLinkTitle は markdown リンク `[title](url)` や Slack mrkdwn `<url|title>` を
+// 壊す文字を、見た目の近い全角文字へ置き換える。
+var sanitizeLinkTitle = strings.NewReplacer(
+	"[", "[", "]", "]",
+	"<", "<", ">", ">",
+	"|", "|",
+).Replace
+
+// sanitizeLinkURL はリンク URL の解釈を途中で打ち切る文字をパーセントエンコードする。
+var sanitizeLinkURL = strings.NewReplacer(
+	"(", "%28", ")", "%29",
+	"<", "%3C", ">", "%3E",
+	"|", "%7C", " ", "%20",
+).Replace

--- a/usecase/notify.go
+++ b/usecase/notify.go
@@ -19,14 +19,14 @@ type NotifyUsecase interface {
 
 type notifyImpl struct {
 	analytics repository.AnalyticsRepository
-	slack     repository.SlackRepository
+	notify    repository.NotifyRepository
 }
 
-// NewNotifyUsecase は分析結果を Slack へ通知するユースケースを生成する
-func NewNotifyUsecase(analytics repository.AnalyticsRepository, slack repository.SlackRepository) NotifyUsecase {
+// NewNotifyUsecase は分析結果を通知先(Slack / Discord)へ通知するユースケースを生成する
+func NewNotifyUsecase(analytics repository.AnalyticsRepository, notify repository.NotifyRepository) NotifyUsecase {
 	return &notifyImpl{
 		analytics: analytics,
-		slack:     slack,
+		notify:    notify,
 	}
 }
 
@@ -49,7 +49,7 @@ func (n *notifyImpl) Run(ctx context.Context) error {
 	// 各期間を並列に取得する。結果はインデックスで格納し、元の順序を保持する。
 	// errgroup の派生 ctx (gctx) は Wait 後にキャンセルされるため取得処理にのみ使い、
 	// 成功通知には元の ctx を使う。
-	rankings := make([]*repository.Post, len(ranges))
+	rankings := make([]*repository.Message, len(ranges))
 	g, gctx := errgroup.WithContext(ctx)
 	for i, r := range ranges {
 		g.Go(func() error {
@@ -65,15 +65,15 @@ func (n *notifyImpl) Run(ctx context.Context) error {
 		return err
 	}
 
-	posts := make([]*repository.Post, 0, len(ranges)+1)
-	posts = append(posts, &repository.Post{
+	msgs := make([]*repository.Message, 0, len(ranges)+1)
+	msgs = append(msgs, &repository.Message{
 		Fallback: os.Getenv("SUCCESS_FALLBACK"),
 		Pretext:  os.Getenv("SUCCESS_FALLBACK"),
 	})
-	posts = append(posts, rankings...)
+	msgs = append(msgs, rankings...)
 
-	if err := n.slack.Post(ctx, os.Getenv("SUCCESS_WEBHOOK_URL"), posts); err != nil {
-		return fmt.Errorf("post to slack: %w", err)
+	if err := n.notify.Post(ctx, os.Getenv("SUCCESS_WEBHOOK_URL"), msgs); err != nil {
+		return fmt.Errorf("post notification: %w", err)
 	}
 
 	return nil
@@ -82,10 +82,11 @@ func (n *notifyImpl) Run(ctx context.Context) error {
 func (n *notifyImpl) Error(ctx context.Context, err error) {
 	slog.ErrorContext(ctx, "notify failed", slog.Any("error", err))
 
-	posts := []*repository.Post{
+	msgs := []*repository.Message{
 		{
 			Fallback: os.Getenv("FAILD_FALLBACK"),
-			Pretext:  "<@" + os.Getenv("SLACK_ID") + "> " + os.Getenv("FAILD_FALLBACK"),
+			Mention:  true,
+			Pretext:  os.Getenv("FAILD_FALLBACK"),
 			Title:    err.Error(),
 			Color:    "#EB4646",
 			Footer:   "analytics_notifications_slack",
@@ -97,21 +98,22 @@ func (n *notifyImpl) Error(ctx context.Context, err error) {
 	notifyCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 	defer cancel()
 
-	if postErr := n.slack.Post(notifyCtx, os.Getenv("FAILD_WEBHOOK_URL"), posts); postErr != nil {
-		slog.ErrorContext(ctx, "failed to post error to slack", slog.Any("error", postErr))
+	if postErr := n.notify.Post(notifyCtx, os.Getenv("FAILD_WEBHOOK_URL"), msgs); postErr != nil {
+		slog.ErrorContext(ctx, "failed to post error notification", slog.Any("error", postErr))
 	}
 }
 
-func (n *notifyImpl) createRankingData(title string, color string, data []*repository.Page) *repository.Post {
+func (n *notifyImpl) createRankingData(title string, color string, data []*repository.Page) *repository.Message {
 	text := []string{}
 	for i, item := range data {
 		if i >= 5 {
 			break
 		}
-		text = append(text, fmt.Sprintf("[%d] <https://%s|%s>: %dpv", i+1, item.Path, item.Title, item.PV))
+		// リンクは中立表現の markdown 形式で保持し、変換は各アダプタに任せる。
+		text = append(text, fmt.Sprintf("[%d] [%s](https://%s): %dpv", i+1, item.Title, item.Path, item.PV))
 	}
 
-	return &repository.Post{
+	return &repository.Message{
 		Title: title,
 		Text:  strings.Join(text, "\n"),
 		Color: color,

--- a/usecase/notify_test.go
+++ b/usecase/notify_test.go
@@ -69,10 +69,18 @@ func TestCreateRankingDataSanitizesLinkParts(t *testing.T) {
 	msg := n.createRankingData("t", "#000", pages)
 
 	// markdown リンクを壊す文字はタイトルでは全角へ、URL ではパーセント
-	// エンコードへ置き換えられる。
-	want := "[1] [[Go] <generics|tips>](https://h/foo%28bar%29%20baz): 1pv"
+	// エンコードへ置き換えられる。期待値の全角文字は ASCII への正規化で
+	// テストが素通りしないよう Unicode エスケープで明示する。
+	want := "[1] [［Go］ ＜generics｜tips＞](https://h/foo%28bar%29%20baz): 1pv"
 	if msg.Text != want {
 		t.Errorf("text = %q, want %q", msg.Text, want)
+	}
+	// 期待値の全角文字が ASCII に化けてテストが素通りしないよう、
+	// 元の ASCII 文字が消えていることも直接検証する。
+	for _, ng := range []string{"[Go]", "<generics", "|tips>", "(bar)", " baz"} {
+		if strings.Contains(msg.Text, ng) {
+			t.Errorf("text still contains unsanitized %q: %q", ng, msg.Text)
+		}
 	}
 }
 

--- a/usecase/notify_test.go
+++ b/usecase/notify_test.go
@@ -60,6 +60,22 @@ func TestCreateRankingData(t *testing.T) {
 	}
 }
 
+func TestCreateRankingDataSanitizesLinkParts(t *testing.T) {
+	n := &notifyImpl{}
+	pages := []*repository.Page{
+		{Title: "[Go] <generics|tips>", Path: "h/foo(bar) baz", PV: 1},
+	}
+
+	msg := n.createRankingData("t", "#000", pages)
+
+	// markdown リンクを壊す文字はタイトルでは全角へ、URL ではパーセント
+	// エンコードへ置き換えられる。
+	want := "[1] [[Go] <generics|tips>](https://h/foo%28bar%29%20baz): 1pv"
+	if msg.Text != want {
+		t.Errorf("text = %q, want %q", msg.Text, want)
+	}
+}
+
 func TestCreateRankingDataFewerThanFive(t *testing.T) {
 	n := &notifyImpl{}
 	pages := []*repository.Page{{Title: "a", Path: "h/a", PV: 3}}

--- a/usecase/notify_test.go
+++ b/usecase/notify_test.go
@@ -24,16 +24,16 @@ func (f *fakeAnalytics) GetSessions(_ context.Context, _ string, _ string) ([]*r
 	return f.pages, nil
 }
 
-type fakeSlack struct {
-	posts    [][]*repository.Post
+type fakeNotify struct {
+	posts    [][]*repository.Message
 	paths    []string
 	postErrs []error // Post 呼び出し時点の ctx.Err()
 	err      error
 }
 
-func (f *fakeSlack) Post(ctx context.Context, path string, msg []*repository.Post) error {
-	f.paths = append(f.paths, path)
-	f.posts = append(f.posts, msg)
+func (f *fakeNotify) Post(ctx context.Context, webhookURL string, msgs []*repository.Message) error {
+	f.paths = append(f.paths, webhookURL)
+	f.posts = append(f.posts, msgs)
 	f.postErrs = append(f.postErrs, ctx.Err())
 	return f.err
 }
@@ -45,17 +45,18 @@ func TestCreateRankingData(t *testing.T) {
 		pages = append(pages, &repository.Page{Title: "t", Path: "h/p", PV: i})
 	}
 
-	post := n.createRankingData("ランキング", "#fff", pages)
+	msg := n.createRankingData("ランキング", "#fff", pages)
 
-	if post.Title != "ランキング" || post.Color != "#fff" {
-		t.Errorf("unexpected title/color: %+v", post)
+	if msg.Title != "ランキング" || msg.Color != "#fff" {
+		t.Errorf("unexpected title/color: %+v", msg)
 	}
 	// 上位5件のみが描画される。
-	if lines := strings.Count(post.Text, "\n") + 1; lines != 5 {
+	if lines := strings.Count(msg.Text, "\n") + 1; lines != 5 {
 		t.Errorf("got %d lines, want 5", lines)
 	}
-	if !strings.Contains(post.Text, "[1] <https://h/p|t>: 0pv") {
-		t.Errorf("unexpected first line: %q", post.Text)
+	// リンクは中立表現の markdown 形式で保持される。
+	if !strings.Contains(msg.Text, "[1] [t](https://h/p): 0pv") {
+		t.Errorf("unexpected first line: %q", msg.Text)
 	}
 }
 
@@ -63,10 +64,10 @@ func TestCreateRankingDataFewerThanFive(t *testing.T) {
 	n := &notifyImpl{}
 	pages := []*repository.Page{{Title: "a", Path: "h/a", PV: 3}}
 
-	post := n.createRankingData("t", "#000", pages)
+	msg := n.createRankingData("t", "#000", pages)
 
-	if post.Text != "[1] <https://h/a|a>: 3pv" {
-		t.Errorf("unexpected text: %q", post.Text)
+	if msg.Text != "[1] [a](https://h/a): 3pv" {
+		t.Errorf("unexpected text: %q", msg.Text)
 	}
 }
 
@@ -75,8 +76,8 @@ func TestRunSuccess(t *testing.T) {
 	t.Setenv("SUCCESS_FALLBACK", "ok")
 
 	analytics := &fakeAnalytics{pages: []*repository.Page{{Title: "a", Path: "h/a", PV: 1}}}
-	slack := &fakeSlack{}
-	n := NewNotifyUsecase(analytics, slack)
+	notify := &fakeNotify{}
+	n := NewNotifyUsecase(analytics, notify)
 
 	if err := n.Run(context.Background()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -86,25 +87,25 @@ func TestRunSuccess(t *testing.T) {
 	if got := analytics.calls.Load(); got != 3 {
 		t.Errorf("GetSessions called %d times, want 3", got)
 	}
-	if len(slack.posts) != 1 {
-		t.Fatalf("slack posted %d times, want 1", len(slack.posts))
+	if len(notify.posts) != 1 {
+		t.Fatalf("notify posted %d times, want 1", len(notify.posts))
 	}
-	if slack.paths[0] != "https://hooks.example/success" {
-		t.Errorf("posted to %q", slack.paths[0])
+	if notify.paths[0] != "https://hooks.example/success" {
+		t.Errorf("posted to %q", notify.paths[0])
 	}
 	// 成功通知には、errgroup の Wait 後にキャンセルされる派生 ctx ではなく
 	// 有効な ctx が渡されなければならない。
-	if slack.postErrs[0] != nil {
-		t.Errorf("slack.Post received a cancelled context: %v", slack.postErrs[0])
+	if notify.postErrs[0] != nil {
+		t.Errorf("notify.Post received a cancelled context: %v", notify.postErrs[0])
 	}
-	// 先頭のフォールバック + 3つのランキング添付が順番通りに並ぶ。
-	if got := len(slack.posts[0]); got != 4 {
-		t.Fatalf("attachments = %d, want 4", got)
+	// 先頭のフォールバック + 3つのランキングが順番通りに並ぶ。
+	if got := len(notify.posts[0]); got != 4 {
+		t.Fatalf("messages = %d, want 4", got)
 	}
 	wantTitles := []string{"", "今日のpv数ランキング", "今月のpv数ランキング", "累計pv数ランキング"}
 	for i, want := range wantTitles {
-		if got := slack.posts[0][i].Title; got != want {
-			t.Errorf("attachment %d title = %q, want %q", i, got, want)
+		if got := notify.posts[0][i].Title; got != want {
+			t.Errorf("message %d title = %q, want %q", i, got, want)
 		}
 	}
 }
@@ -112,42 +113,45 @@ func TestRunSuccess(t *testing.T) {
 func TestRunAnalyticsError(t *testing.T) {
 	wantErr := errors.New("boom")
 	analytics := &fakeAnalytics{err: wantErr}
-	slack := &fakeSlack{}
-	n := NewNotifyUsecase(analytics, slack)
+	notify := &fakeNotify{}
+	n := NewNotifyUsecase(analytics, notify)
 
 	err := n.Run(context.Background())
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("error = %v, want wrap of %v", err, wantErr)
 	}
-	if len(slack.posts) != 0 {
-		t.Errorf("slack should not be posted on analytics failure")
+	if len(notify.posts) != 0 {
+		t.Errorf("notify should not be posted on analytics failure")
 	}
 }
 
 func TestError(t *testing.T) {
 	t.Setenv("FAILD_WEBHOOK_URL", "https://hooks.example/fail")
 	t.Setenv("FAILD_FALLBACK", "failed")
-	t.Setenv("SLACK_ID", "U123")
 
-	slack := &fakeSlack{}
-	n := NewNotifyUsecase(&fakeAnalytics{}, slack)
+	notify := &fakeNotify{}
+	n := NewNotifyUsecase(&fakeAnalytics{}, notify)
 
 	// 既にキャンセル済みのコンテキストでも通知は送られなければならない。
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	n.Error(ctx, errors.New("something broke"))
 
-	if len(slack.posts) != 1 {
-		t.Fatalf("slack posted %d times, want 1", len(slack.posts))
+	if len(notify.posts) != 1 {
+		t.Fatalf("notify posted %d times, want 1", len(notify.posts))
 	}
-	if slack.paths[0] != "https://hooks.example/fail" {
-		t.Errorf("posted to %q", slack.paths[0])
+	if notify.paths[0] != "https://hooks.example/fail" {
+		t.Errorf("posted to %q", notify.paths[0])
 	}
-	post := slack.posts[0][0]
-	if post.Title != "something broke" {
-		t.Errorf("title = %q", post.Title)
+	msg := notify.posts[0][0]
+	if msg.Title != "something broke" {
+		t.Errorf("title = %q", msg.Title)
 	}
-	if !strings.Contains(post.Pretext, "<@U123>") {
-		t.Errorf("pretext missing mention: %q", post.Pretext)
+	// メンションの形式変換はアダプタに任せるため、usecase はフラグのみ立てる。
+	if !msg.Mention {
+		t.Errorf("mention flag should be set")
+	}
+	if msg.Pretext != "failed" {
+		t.Errorf("pretext = %q, want %q", msg.Pretext, "failed")
 	}
 }


### PR DESCRIPTION
resolve #65

## 概要

環境変数 `NOTIFY_MODE`(`slack` | `discord`、未設定時は `slack`)で投稿先を切り替える discord モードを追加します。エラー通知(Alert)を含めて Discord へ移行できます。issue #65 の実装プランに沿った変更です。

## 変更内容

### 中立モデルと送信インターフェースの導入(`repository/notify.go` 新規)
- `repository.Message` — 投稿先サービスに依存しない中立な通知モデル(fallback / mention フラグ / pretext / title / text / color(hex) / footer)
- `repository.NotifyRepository` — `Post(ctx, webhookURL, msgs)` を持つ共通インターフェース
- リンクは中立表現の markdown 形式 `[title](url)` で保持し、変換は各アダプタが担当(リンクを壊す文字はタイトルは全角置換、URL はパーセントエンコードでサニタイズ)

### Discord アダプタの追加(`repository/discord.go` 新規)
- webhook へ JSON POST(`Content-Type: application/json`)
- 全体通知 `@everyone` と pretext は content に、title / description / color / footer は embeds に出力(embed 内ではメンションが機能しないため)
- color は hex 文字列 → 整数へ変換
- Discord の制約への対応: embeds 10件・文字数合計6000字ごとのチャンク送信 / title 256字・description 4096字・footer 2048字・content 2000字の切り詰め / エラー時は現状同様エラーを返して Lambda を失敗させる

### Slack アダプタ化(`repository/slack.go`)
- `NotifyRepository` を実装し、`Message` → attachment 変換とリンク形式変換(`[title](url)` → mrkdwn)を内部に移動
- 送信形式(Incoming Webhook + legacy attachments、form-urlencoded)は従来どおり

### usecase / handler
- `usecase/notify.go`: 依存を `NotifyRepository` に差し替え、`Error` のメンション埋め込みを Mention フラグに中立化(キャンセル切り離しコンテキストでの失敗通知など既存挙動は維持)
- `handler/main.go`: `NOTIFY_MODE` によるアダプタ生成分岐(遅延初期化・ウォームスタート間キャッシュ、analytics 初期化失敗時の失敗通知経路は維持)

### 環境変数
- 追加: `NOTIFY_MODE`(既定 `slack`)
- 廃止: `SLACK_ID` — エラー時のメンションはユーザー個人宛から全体通知(Slack: `<!channel>`、Discord: `@everyone`)に変更
- `SUCCESS_WEBHOOK_URL` / `FAILD_WEBHOOK_URL` はそのまま流用(discord モード時は Discord webhook URL を設定)

### テスト
- `repository/discord_test.go`(新規): ペイロード形状、色変換、件数・文字数合計チャンク、文字数切り詰め、HTTP エラー時の挙動(httptest 使用)
- `repository/slack_test.go`(新規): `Message` → attachment 変換とリンク形式変換
- `usecase/notify_test.go`: モックを `NotifyRepository` に更新し回帰確認、リンクサニタイズの検証を追加

`go vet ./...` / `go test ./...` green 確認済み。

## 動作確認(デプロイ環境での確認が必要)

- [ ] dev ステージへデプロイし、Discord へのランキング投稿(リンク・色・footer)を確認
- [ ] 意図的に例外を発生させ、Alert が Discord に届き全体通知(`@everyone`)が機能することを確認
- [ ] `NOTIFY_MODE` 未設定時に従来どおり Slack へ投稿されること(後方互換)を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kt1m6AJzx4NY3igZgDHwAq