### PR TITLE
ci: issue/PR作成時に自動アサインするworkflowを追加

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,25 @@
+name: auto-assign
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  assign:
+    name: assign
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: assign limit7412
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api "repos/$REPO/issues/$NUMBER/assignees" \
+            -f "assignees[]=limit7412"


### PR DESCRIPTION
## 概要

issue / PR が作成されたときに `limit7412` を自動でアサインする GitHub Actions workflow を追加します。

Closes #68

## 変更内容

- `.github/workflows/auto-assign.yml` を追加
  - トリガー: `issues: [opened]` / `pull_request_target: [opened]`
  - `permissions` は `issues: write` / `pull-requests: write` のみに限定
  - `gh api repos/{repo}/issues/{number}/assignees` でアサインを追加

issue に記載の参照実装 (`limit7412/VRCARKitBlendShapeGenerator` の `auto-assign.yml`) をベースに、本リポジトリの既存 workflow の記法に合わせています。

- ジョブ名を小文字表記に統一 (`name: auto-assign` / `name: assign`)
- runner を他の workflow と同じ `ubuntu-24.04-arm` に変更

## 補足

fork からの PR でも token が必要なため、`pull_request` ではなく `pull_request_target` を使用しています。実行されるのはベースブランチ側の workflow 定義で、チェックアウトも行わないため fork のコードは実行されません。


---
_Generated by [Claude Code](https://claude.ai/code/session_011a2zJhjKVSHy2Uo8arePr6)_